### PR TITLE
fix CWeather::AddSandStormParticles

### DIFF
--- a/source/game_sa/Weather.cpp
+++ b/source/game_sa/Weather.cpp
@@ -102,8 +102,8 @@ void CWeather::AddRain() {
 // 0x72A820
 void CWeather::AddSandStormParticles() {
     CVector position = TheCamera.GetPosition();
-    position.x += TheCamera.m_mCameraMatrix.GetForward().x * 10.0f;
-    position.y += TheCamera.m_mCameraMatrix.GetForward().y * 10.0f;
+    position.x += TheCamera.m_mCameraMatrix.GetUp().x * 10.0f;
+    position.y += TheCamera.m_mCameraMatrix.GetUp().y * 10.0f;
 
     position.x += CGeneral::GetRandomNumberInRange(0.0f, 40.0f) - 20.0f;
     position.y += CGeneral::GetRandomNumberInRange(0.0f, 40.0f) - 20.0f;


### PR DESCRIPTION
In the original, the up part of the matrix was used, but the reversed code uses the front part
```
v4.x = TheCamera.m_mCameraMatrix.up.x * 10.0 + x;
v4.y = TheCamera.m_mCameraMatrix.up.y * 10.0 + y;
v3.x = (double)rand() * 0.000030518509 * 40.0 + v4.x - 20.0;
v3.y = (double)rand() * 0.000030518509 * 40.0 + v4.y - 20.0;
v3.z = (double)rand() * 0.000030518509 * 7.0 + v3.z - 2.0;
```