### PR TITLE
Fix CTaskSimpleHoldEntity::StartAnim crash

### DIFF
--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
@@ -385,11 +385,10 @@ void CTaskSimpleHoldEntity::StartAnim(CPed* ped) {
     } else {
         if (m_nAnimGroupId && !m_pAnimBlock) {
             CAnimBlock* animBlock = CAnimManager::GetAnimationBlock(m_nAnimGroupId);
-            const auto blockIndex = CAnimManager::GetAnimationBlockIndex(animBlock);
-
             if (!animBlock) {
                 animBlock = CAnimManager::GetAnimationBlock(CAnimManager::GetAnimBlockName(m_nAnimGroupId));
             }
+            const auto blockIndex = CAnimManager::GetAnimationBlockIndex(animBlock);
             if (!animBlock->bLoaded) {
                 CStreaming::RequestModel(IFPToModelId(blockIndex), STREAMING_KEEP_IN_MEMORY);
                 return;


### PR DESCRIPTION
The crash was probably introduced during refactor. Tested fix.