### PR TITLE
HooksDebug: SliderSetter

### DIFF
--- a/source/toolsmenu/DebugModules/HooksDebugModule.h
+++ b/source/toolsmenu/DebugModules/HooksDebugModule.h
@@ -2,11 +2,30 @@
 
 #include "DebugModule.h"
 
+namespace ReversibleHooks {
+class HookCategory;
+};
+
 class HooksDebugModule : public DebugModule {
+    enum class SlideSetterMode {
+        NONE,
+        SETTER, // This mode turns into either `TURN_OFF` OR `TURN_ON` as soon as it's possible
+        TURN_ON,
+        TURN_OFF,
+        TOGGLE
+    };
 public:
     void RenderWindow() override final;
     void RenderMenuEntry() override final;
 
 private:
+    void RenderCategoryItems(ReversibleHooks::HookCategory& cat);
+    void RenderCategory(ReversibleHooks::HookCategory& cat);
+    bool HandleSlideSetterForItem(bool& inOutState); // Returns if state changed
+
+private:
     bool m_IsOpen{};
+    struct {
+        SlideSetterMode Mode;
+    } m_SlideSetter{};
 };

--- a/source/toolsmenu/UIRenderer.cpp
+++ b/source/toolsmenu/UIRenderer.cpp
@@ -71,8 +71,8 @@ void UIRenderer::UpdateInput() {
             m_ImIO->MouseWheel += (WHEEL_SPEED * m_ImIO->DeltaTime);
 
         m_ImIO->MouseDown[ImGuiMouseButton_Left]   = CPad::NewMouseControllerState.lmb;
-        m_ImIO->MouseDown[ImGuiMouseButton_Right]  = CPad::NewMouseControllerState.mmb;
-        m_ImIO->MouseDown[ImGuiMouseButton_Middle] = CPad::NewMouseControllerState.rmb;
+        m_ImIO->MouseDown[ImGuiMouseButton_Right]  = CPad::NewMouseControllerState.rmb;
+        m_ImIO->MouseDown[ImGuiMouseButton_Middle] = CPad::NewMouseControllerState.mmb;
 
         CPad::NewMouseControllerState.X = 0.0f;
         CPad::NewMouseControllerState.Y = 0.0f;


### PR DESCRIPTION
A little feature that allows changing hook state just by sliding the mouse cursor over it while holding a button.
Controls:
- Right click held + Slide = Set all hooks to the same state as the one over which the mouse was when the right click was pressed
- Middle button held + Slide = Toggle all hooks - Kinda buggy if you slide it too fast, i recommend using the right click version
That's about it. I just found it useful when trying to hunt down a bug and had to manually reactivate a lot of hooks. Bonus is that when holding the right mouse button you can still scroll.