### PR TITLE
Fix Col V0 crashing game (Caused by incorrect cast)

### DIFF
--- a/source/game_sa/Collision/ColTriangle.h
+++ b/source/game_sa/Collision/ColTriangle.h
@@ -9,7 +9,7 @@
 class CColTriangle {
 public:
     CColTriangle() = default;
-    CColTriangle(uint16 a, uint16 b, uint16 c, eSurfaceType material, uint8 light) :
+    CColTriangle(uint16 a, uint16 b, uint16 c, eSurfaceType material, tColLighting light) :
           m_nVertA(a),
           m_nVertB(b),
           m_nVertC(c),
@@ -38,6 +38,6 @@ public:
         uint16 m_vertIndices[3];
     };
     eSurfaceType m_nMaterial;
-    uint8 m_nLight;
+    tColLighting m_nLight;
 };
 VALIDATE_SIZE(CColTriangle, 0x8);

--- a/source/game_sa/Collision/CollisionData.h
+++ b/source/game_sa/Collision/CollisionData.h
@@ -96,7 +96,7 @@ public:
     auto GetBoxes()        const { return std::span{ m_pBoxes, m_nNumBoxes }; }
 
     auto GetTris()         const { return std::span{ m_pTriangles, m_nNumTriangles }; }
-    auto GetTriVerts()     const { return m_pVertices; } // Sadly there's no easy way to provide a span here
+    auto GetTriVerts()     const { return m_pVertices; } // Sadly there's no easy way to provide a span here - we don't know the number of vertices, and finding it is expensive
 
     auto GetShdwTris()     const { return std::span{ m_pShadowTriangles, m_nNumShadowTriangles }; }
     auto GetShdwTriVerts() const { return std::span{ m_pShadowVertices, m_nNumShadowVertices }; }

--- a/source/game_sa/Plant/PlantLocTri.cpp
+++ b/source/game_sa/Plant/PlantLocTri.cpp
@@ -22,7 +22,7 @@ void CPlantLocTri::InjectHooks() {
 }
 
 // 0x5DC290
-CPlantLocTri* CPlantLocTri::Add(const CVector& p1, const CVector& p2, const CVector& p3, uint8 surface, uint8 lightning, bool createsPlants, bool createsObjects) {
+CPlantLocTri* CPlantLocTri::Add(const CVector& p1, const CVector& p2, const CVector& p3, uint8 surface, tColLighting lightning, bool createsPlants, bool createsObjects) {
     m_V1 = p1;
     m_V2 = p2;
     m_V3 = p3;

--- a/source/game_sa/Plant/PlantLocTri.h
+++ b/source/game_sa/Plant/PlantLocTri.h
@@ -12,7 +12,7 @@ public:
     std::array<float, 3> m_Seed;
     uint16 m_nMaxNumPlants[3];
     uint8 m_SurfaceId;
-    uint8 m_nLighting;
+    tColLighting m_nLighting;
 
     union {
         struct {
@@ -30,7 +30,7 @@ public:
 public:
     static void InjectHooks();
 
-    CPlantLocTri* Add(const CVector& p1, const CVector& p2, const CVector& p3, uint8 surface, uint8 lightning, bool createsPlants, bool createsObjects);
+    CPlantLocTri* Add(const CVector& p1, const CVector& p2, const CVector& p3, uint8 surface, tColLighting lightning, bool createsPlants, bool createsObjects);
     void Release();
 };
 VALIDATE_SIZE(CPlantLocTri, 0x54);


### PR DESCRIPTION
Collision (4CC "COLL") crashed the game (Seems like very rarely do models have this version used, but some RC vehicle did, so I crashed)
Fix was pretty easy, there was a bad cast `*reinterpret_cast<tColLighting*>(nLigthing)`, now I've removed the casts completely, that's why there's a little more changes than expected. 