### PR TITLE
New CMatrix functions for point transformation (Inspired by UE funcs)

### DIFF
--- a/source/extensions/Shapes/AngledRect.cpp
+++ b/source/extensions/Shapes/AngledRect.cpp
@@ -24,8 +24,8 @@ void AngledRect::DrawWireFrame(CRGBA color, float z, const CMatrix& transform) c
     // Calculate corners
     CVector corners[4];
     rng::transform(GetCorners(), corners, [&](auto& c) {
-        return transform * CVector{ c.x, c.y, z };
-        });
+        return transform.TransformPoint(CVector{ c.x, c.y, z });
+    });
 
     // Draw lines going from one corner to another
     for (auto i = 0u; i < 4; i++) {
@@ -38,7 +38,7 @@ void AngledRect::DrawWireFrame(CRGBA color, float z, const CMatrix& transform) c
 
 void AngledRect::HighlightWithMarkers(const CMatrix& transform) const {
     for (const auto& corner : GetCorners()) {
-        auto corner3D = transform * CVector{ corner, CWorld::FindGroundZForCoord(corner.x, corner.y) };
+        auto corner3D = transform.TransformPoint(CVector{ corner, CWorld::FindGroundZForCoord(corner.x, corner.y) });
         C3dMarkers::PlaceMarkerSet(
             reinterpret_cast<uint32>(this) + rand(),
             MARKER3D_CYLINDER,

--- a/source/game_sa/Birds.cpp
+++ b/source/game_sa/Birds.cpp
@@ -349,7 +349,7 @@ void CBirds::Render() {
                         NOTSA_UNREACHABLE("CBirds::Render::lambda suppress warning");
                         return std::make_pair(CVector(), CBirdColor());
                     }();
-                    auto vecWorldPos = matBirdTransform * point;
+                    auto vecWorldPos = matBirdTransform.TransformPoint(point);
 
                     auto iBufferInd = uiTempBufferVerticesStored + uiVertInd;
                     auto vert1 = &aTempBufferVertices[iBufferInd];

--- a/source/game_sa/Birds.cpp
+++ b/source/game_sa/Birds.cpp
@@ -361,7 +361,7 @@ void CBirds::Render() {
 
                     // Mirror on the other side with slightly changed colors
                     point.x = -point.x;
-                    vecWorldPos = matBirdTransform * point;
+                    vecWorldPos = matBirdTransform.TransformPoint(point);
                     color.Scale(0.8F);
                     rwColor = CRGBA(color.cRed, color.cGreen, color.cBlue, cAlpha).ToRwRGBA();
 

--- a/source/game_sa/BouncingPanel.cpp
+++ b/source/game_sa/BouncingPanel.cpp
@@ -36,7 +36,7 @@ void CBouncingPanel::ProcessPanel(CVehicle* vehicle, RwFrame* frame, CVector mov
     CMatrix  frameMat{RwFrameGetMatrix(frame)};
     CMatrix& vehMat = vehicle->GetMatrix();
     CVector  compPos = Multiply3x3_MV(vehMat, frameMat.GetPosition());
-    CVector  angularVelocity = Multiply3x3_VM(vehicle->GetSpeed(compPos) - moveForce + CrossProduct(compPos, turnForce), vehMat);
+    CVector  angularVelocity = vehMat.InverseTransformVector(vehicle->GetSpeed(compPos) - moveForce + CrossProduct(compPos, turnForce));
 
     switch (m_nAxis) {
     case 0: {

--- a/source/game_sa/BouncingPanel.cpp
+++ b/source/game_sa/BouncingPanel.cpp
@@ -35,8 +35,8 @@ float CBouncingPanel::GetAngleChange(float velocity) const {
 void CBouncingPanel::ProcessPanel(CVehicle* vehicle, RwFrame* frame, CVector moveForce, CVector turnForce, float fReturnMultiplier, float fDampMultiplier) {
     CMatrix  frameMat{RwFrameGetMatrix(frame)};
     CMatrix& vehMat = vehicle->GetMatrix();
-    CVector  compPos = Multiply3x3(vehMat, frameMat.GetPosition());
-    CVector  angularVelocity = Multiply3x3(vehicle->GetSpeed(compPos) - moveForce + CrossProduct(compPos, turnForce), vehMat);
+    CVector  compPos = Multiply3x3_MV(vehMat, frameMat.GetPosition());
+    CVector  angularVelocity = Multiply3x3_VM(vehicle->GetSpeed(compPos) - moveForce + CrossProduct(compPos, turnForce), vehMat);
 
     switch (m_nAxis) {
     case 0: {

--- a/source/game_sa/BouncingPanel.cpp
+++ b/source/game_sa/BouncingPanel.cpp
@@ -35,7 +35,7 @@ float CBouncingPanel::GetAngleChange(float velocity) const {
 void CBouncingPanel::ProcessPanel(CVehicle* vehicle, RwFrame* frame, CVector moveForce, CVector turnForce, float fReturnMultiplier, float fDampMultiplier) {
     CMatrix  frameMat{RwFrameGetMatrix(frame)};
     CMatrix& vehMat = vehicle->GetMatrix();
-    CVector  compPos = Multiply3x3_MV(vehMat, frameMat.GetPosition());
+    CVector  compPos = vehMat.TransformVector(frameMat.GetPosition());
     CVector  angularVelocity = vehMat.InverseTransformVector(vehicle->GetSpeed(compPos) - moveForce + CrossProduct(compPos, turnForce));
 
     switch (m_nAxis) {

--- a/source/game_sa/BreakObject_c.cpp
+++ b/source/game_sa/BreakObject_c.cpp
@@ -50,7 +50,7 @@ bool BreakObject_c::Init(CObject* object, const CVector* velocity, float fVeloci
     if (info->m_uiPosRule != eBreakablePluginPositionRule::OBJECT_ORIGIN) {
         auto usedPoint = colModel->GetBoundingBox().GetCenter();
         usedPoint.z += 0.25f;
-        vecOrigin = *object->m_matrix * usedPoint;
+        vecOrigin = object->m_matrix->TransformPoint(usedPoint);
     } else {
         vecOrigin = *RwMatrixGetPos(ltm);
         vecOrigin.z += colModel->GetBoundingBox().m_vecMin.z + 0.25f;

--- a/source/game_sa/Buoyancy.cpp
+++ b/source/game_sa/Buoyancy.cpp
@@ -119,7 +119,7 @@ bool cBuoyancy::ProcessBuoyancyBoat(CVehicle* vehicle, float fBuoyancy, CVector*
             auto fPointContribution = fCurBuoyancy * (fAddedDistToSurface * fBoatHeightRatio);
 
             CVector vecOffset(fCurrentX, fCurrentY, 0.0F);
-            CVector vecTransformedPos = Multiply3x3(vehicle->GetMatrix(), vecOffset);
+            CVector vecTransformedPos = Multiply3x3_MV(vehicle->GetMatrix(), vecOffset);
 
             CVector vecSpeedAtPoint = vehicle->GetSpeed(vecTransformedPos);
             auto handling = vehicle->m_pHandlingData;
@@ -130,14 +130,14 @@ bool cBuoyancy::ProcessBuoyancyBoat(CVehicle* vehicle, float fBuoyancy, CVector*
 
             if (!bUnderwater) {
                 auto vecTurnForceAtPoint = vecWaveNormal * fWavePower;
-                CVector vecAppliedForcePoint = Multiply3x3(m_EntityMatrix, vecCurPoint);
+                CVector vecAppliedForcePoint = Multiply3x3_MV(m_EntityMatrix, vecCurPoint);
                 vehicle->ApplyTurnForce(vecTurnForceAtPoint, vecAppliedForcePoint);
             }
         }
     }
 
     m_fEntityWaterImmersion *= fBoatHeightRatio;
-    *vecBuoyancyTurnPoint = Multiply3x3(m_EntityMatrix, m_vecTurnPoint);
+    *vecBuoyancyTurnPoint = Multiply3x3_MV(m_EntityMatrix, m_vecTurnPoint);
 
     if (m_bProcessingBoat)
         return true;
@@ -150,7 +150,7 @@ bool cBuoyancy::CalcBuoyancyForce(CPhysical* entity, CVector* vecBuoyancyTurnPoi
     if (!m_bInWater)
         return false;
 
-    *vecBuoyancyTurnPoint = Multiply3x3(m_EntityMatrix, m_vecTurnPoint);
+    *vecBuoyancyTurnPoint = Multiply3x3_MV(m_EntityMatrix, m_vecTurnPoint);
     auto fCurrentBuoyancy = m_fEntityWaterImmersion * m_fBuoyancy * CTimer::GetTimeStep();
     vecBuoyancyForce->Set(0.0F, 0.0F, fCurrentBuoyancy);
 
@@ -445,7 +445,7 @@ float cBuoyancy::SimpleSumBuoyancyData(CVector* vecWaterOffset, tWaterLevel ePoi
 
 void cBuoyancy::FindWaterLevel(const CVector& vecInitialZPos, CVector* outVecOffset, tWaterLevel* outInWaterState)
 {
-    CVector transformedPos = Multiply3x3(m_EntityMatrix, *outVecOffset);
+    CVector transformedPos = Multiply3x3_MV(m_EntityMatrix, *outVecOffset);
     auto vecWorldPos = transformedPos + m_vecPos;
     CWaterLevel::GetWaterLevel(vecWorldPos.x, vecWorldPos.y, m_vecPos.z, outVecOffset->z, true, nullptr);
     outVecOffset->z -= (transformedPos.z + vecInitialZPos.z);
@@ -465,7 +465,7 @@ void cBuoyancy::FindWaterLevel(const CVector& vecInitialZPos, CVector* outVecOff
 
 void cBuoyancy::FindWaterLevelNorm(const CVector& vecInitialZPos, CVector* outVecOffset, tWaterLevel* outInWaterState, CVector* outVecNormal)
 {
-    CVector transformedPos = Multiply3x3(m_EntityMatrix, *outVecOffset);
+    CVector transformedPos = Multiply3x3_MV(m_EntityMatrix, *outVecOffset);
     auto vecWorldPos = transformedPos + m_vecPos;
     CWaterLevel::GetWaterLevel(vecWorldPos.x, vecWorldPos.y, m_vecPos.z, outVecOffset->z, true, outVecNormal);
     outVecOffset->z -= (transformedPos.z + vecInitialZPos.z);

--- a/source/game_sa/Buoyancy.cpp
+++ b/source/game_sa/Buoyancy.cpp
@@ -119,7 +119,7 @@ bool cBuoyancy::ProcessBuoyancyBoat(CVehicle* vehicle, float fBuoyancy, CVector*
             auto fPointContribution = fCurBuoyancy * (fAddedDistToSurface * fBoatHeightRatio);
 
             CVector vecOffset(fCurrentX, fCurrentY, 0.0F);
-            CVector vecTransformedPos = Multiply3x3_MV(vehicle->GetMatrix(), vecOffset);
+            CVector vecTransformedPos = vehicle->GetMatrix().TransformVector(vecOffset);
 
             CVector vecSpeedAtPoint = vehicle->GetSpeed(vecTransformedPos);
             auto handling = vehicle->m_pHandlingData;
@@ -130,14 +130,14 @@ bool cBuoyancy::ProcessBuoyancyBoat(CVehicle* vehicle, float fBuoyancy, CVector*
 
             if (!bUnderwater) {
                 auto vecTurnForceAtPoint = vecWaveNormal * fWavePower;
-                CVector vecAppliedForcePoint = Multiply3x3_MV(m_EntityMatrix, vecCurPoint);
+                CVector vecAppliedForcePoint = m_EntityMatrix.TransformVector(vecCurPoint);
                 vehicle->ApplyTurnForce(vecTurnForceAtPoint, vecAppliedForcePoint);
             }
         }
     }
 
     m_fEntityWaterImmersion *= fBoatHeightRatio;
-    *vecBuoyancyTurnPoint = Multiply3x3_MV(m_EntityMatrix, m_vecTurnPoint);
+    *vecBuoyancyTurnPoint = m_EntityMatrix.TransformVector(m_vecTurnPoint);
 
     if (m_bProcessingBoat)
         return true;
@@ -150,7 +150,7 @@ bool cBuoyancy::CalcBuoyancyForce(CPhysical* entity, CVector* vecBuoyancyTurnPoi
     if (!m_bInWater)
         return false;
 
-    *vecBuoyancyTurnPoint = Multiply3x3_MV(m_EntityMatrix, m_vecTurnPoint);
+    *vecBuoyancyTurnPoint = m_EntityMatrix.TransformVector(m_vecTurnPoint);
     auto fCurrentBuoyancy = m_fEntityWaterImmersion * m_fBuoyancy * CTimer::GetTimeStep();
     vecBuoyancyForce->Set(0.0F, 0.0F, fCurrentBuoyancy);
 
@@ -445,7 +445,7 @@ float cBuoyancy::SimpleSumBuoyancyData(CVector* vecWaterOffset, tWaterLevel ePoi
 
 void cBuoyancy::FindWaterLevel(const CVector& vecInitialZPos, CVector* outVecOffset, tWaterLevel* outInWaterState)
 {
-    CVector transformedPos = Multiply3x3_MV(m_EntityMatrix, *outVecOffset);
+    CVector transformedPos = m_EntityMatrix.TransformVector(*outVecOffset);
     auto vecWorldPos = transformedPos + m_vecPos;
     CWaterLevel::GetWaterLevel(vecWorldPos.x, vecWorldPos.y, m_vecPos.z, outVecOffset->z, true, nullptr);
     outVecOffset->z -= (transformedPos.z + vecInitialZPos.z);
@@ -465,7 +465,7 @@ void cBuoyancy::FindWaterLevel(const CVector& vecInitialZPos, CVector* outVecOff
 
 void cBuoyancy::FindWaterLevelNorm(const CVector& vecInitialZPos, CVector* outVecOffset, tWaterLevel* outInWaterState, CVector* outVecNormal)
 {
-    CVector transformedPos = Multiply3x3_MV(m_EntityMatrix, *outVecOffset);
+    CVector transformedPos = m_EntityMatrix.TransformVector(*outVecOffset);
     auto vecWorldPos = transformedPos + m_vecPos;
     CWaterLevel::GetWaterLevel(vecWorldPos.x, vecWorldPos.y, m_vecPos.z, outVecOffset->z, true, outVecNormal);
     outVecOffset->z -= (transformedPos.z + vecInitialZPos.z);

--- a/source/game_sa/Buoyancy.cpp
+++ b/source/game_sa/Buoyancy.cpp
@@ -289,7 +289,7 @@ void cBuoyancy::AddSplashParticles(CPhysical* entity, CVector vecFrom, CVector v
     for (int32 iIter = 0; iIter < iNumParticles; ++iIter) {
         auto fCurrentProgress = static_cast<float>(iIter) / static_cast<float>(iNumParticles);
         auto vecCurPoint = Lerp(vecFrom, vecTo, fCurrentProgress);
-        auto vecTransformedPoint = (*entity->m_matrix) * vecCurPoint;
+        auto vecTransformedPoint = entity->m_matrix->TransformPoint(vecCurPoint);
 
         if (!entity->IsPed()) {
             const auto& vecEntPos = entity->GetPosition();

--- a/source/game_sa/CarEnterExit.cpp
+++ b/source/game_sa/CarEnterExit.cpp
@@ -417,8 +417,8 @@ bool CCarEnterExit::IsPathToDoorBlockedByVehicleCollisionModel(const CPed* ped, 
 
     const auto vehMatInv = Invert(*vehicle->m_matrix);
     const CColLine line{
-        vehMatInv * ped->GetPosition(),
-        vehMatInv * pos
+        vehMatInv.TransformPoint(ped->GetPosition()),
+        vehMatInv.TransformPoint(pos)
     };
 
     for (const auto& sp : vehicle->GetColModel()->GetData()->GetSpheres()) {

--- a/source/game_sa/Collision/Box.cpp
+++ b/source/game_sa/Collision/Box.cpp
@@ -32,36 +32,36 @@ void CBox::Recalc()
 // NOTSA - TODO(OPT): Refactor code (meaningful names, etc) and possibly use std::optional for `CMatrix` (In cases where a unity matrix would be used otherwise)
 void CBox::DrawWireFrame(CRGBA color, const CMatrix& transform) const {
     auto workVec = m_vecMin;
-    CVector v1 = transform * workVec;
+    CVector v1 = transform.TransformPoint(workVec);
 
     workVec.z = m_vecMax.z;
-    CVector v2 = transform * workVec;
+    CVector v2 = transform.TransformPoint(workVec);
 
     workVec = m_vecMin;
     workVec.x = m_vecMax.x;
-    CVector v3 = transform * workVec;
+    CVector v3 = transform.TransformPoint(workVec);
 
     workVec = m_vecMin;
     workVec.y = m_vecMax.y;
-    CVector v4 = transform * workVec;
+    CVector v4 = transform.TransformPoint(workVec);
 
     workVec = m_vecMin;
     workVec.y = m_vecMax.y;
     workVec.z = m_vecMax.z;
-    CVector v5 = transform * workVec;
+    CVector v5 = transform.TransformPoint(workVec);
 
     workVec = m_vecMin;
     workVec.x = m_vecMax.x;
     workVec.z = m_vecMax.z;
-    CVector v6 = transform * workVec;
+    CVector v6 = transform.TransformPoint(workVec);
 
     workVec = m_vecMin;
     workVec.x = m_vecMax.x;
     workVec.y = m_vecMax.y;
-    CVector v7 = transform * workVec;
+    CVector v7 = transform.TransformPoint(workVec);
 
     workVec = m_vecMax;
-    CVector v8 = transform * workVec;
+    CVector v8 = transform.TransformPoint(workVec);
 
     const auto colorARGB = color.ToInt();
     CLines::RenderLineNoClipping(v1, v2, colorARGB, colorARGB);

--- a/source/game_sa/Collision/ColLine.cpp
+++ b/source/game_sa/Collision/ColLine.cpp
@@ -30,5 +30,5 @@ float CColLine::DistTo(CVector pt) const {
 // NOTSA
 void CColLine::DrawWireFrame(CRGBA color, const CMatrix& transform) const {
     const auto colorARGB = color.ToInt();
-    CLines::RenderLineNoClipping(transform * m_vecStart, transform * m_vecEnd, colorARGB, colorARGB);
+    CLines::RenderLineNoClipping(transform.TransformPoint(m_vecStart), transform.TransformPoint(m_vecEnd), colorARGB, colorARGB);
 }

--- a/source/game_sa/Collision/ColLine.h
+++ b/source/game_sa/Collision/ColLine.h
@@ -36,7 +36,7 @@ public:
     bool IsVertical() const { return CVector2D{ m_vecStart } == CVector2D{ m_vecEnd }; }
 
     friend auto TransformObject(const CColLine& ln, const CMatrix& transform) -> CColLine {
-        return { transform * ln.m_vecStart, transform * ln.m_vecEnd };
+        return { transform.TransformPoint(ln.m_vecStart), transform.TransformPoint(ln.m_vecEnd) };
     }
 
 public:

--- a/source/game_sa/Collision/ColTriangle.cpp
+++ b/source/game_sa/Collision/ColTriangle.cpp
@@ -4,9 +4,9 @@
 
 // NOTSA
 void CColTriangle::DrawWireFrame(CRGBA color, const CompressedVector* vertices, const CMatrix& transform) const {
-    const CVector a = transform * UncompressVector(vertices[vA]);
-    const CVector b = transform * UncompressVector(vertices[vB]);
-    const CVector c = transform * UncompressVector(vertices[vC]);
+    const CVector a = transform.TransformPoint(UncompressVector(vertices[vA]));
+    const CVector b = transform.TransformPoint(UncompressVector(vertices[vB]));
+    const CVector c = transform.TransformPoint(UncompressVector(vertices[vC]));
 
     const auto colorARGB = color.ToInt();
     CLines::RenderLineNoClipping(a, b, colorARGB, colorARGB);

--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1237,7 +1237,7 @@ bool CCollision::ProcessDiscCollision(
     ZoneScoped;
 
     const auto cp       = matBA * tempTriCol.m_vecPoint;
-    const auto cpNormal = Multiply3x3_MV(matBA, tempTriCol.m_vecNormal);
+    const auto cpNormal = matBA.TransformVector(tempTriCol.m_vecNormal);
     
     if (std::abs((cpNormal * disk.m_vThickness).ComponentwiseSum()) >= 0.77f ||
         std::abs((((cp - disk.m_vecCenter) * disk.m_vThickness).ComponentwiseSum()) >= disk.m_fThickness)
@@ -1757,7 +1757,7 @@ bool CCollision::ProcessLineOfSight(const CColLine& lnws, const CMatrix& transfo
 
     if (localMinTouchDist < maxTouchDistance) {
         colPoint.m_vecPoint = MultiplyMatrixWithVector(transform, colPoint.m_vecPoint);
-        colPoint.m_vecNormal = Multiply3x3_MV(transform, colPoint.m_vecNormal);
+        colPoint.m_vecNormal = transform.TransformVector(colPoint.m_vecNormal);
         maxTouchDistance = localMinTouchDist;
         return true;
     }
@@ -1832,7 +1832,7 @@ bool CCollision::ProcessVerticalLine(
 
     // Transform back from object space
     cp.m_vecPoint  = transform * cp.m_vecPoint;
-    cp.m_vecNormal = Multiply3x3_MV(transform, cp.m_vecNormal);
+    cp.m_vecNormal = transform.TransformVector(cp.m_vecNormal);
 
     if (outColPoly && storedColPoly.valid) {
         for (auto& vtx : storedColPoly.verts) {

--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1236,7 +1236,7 @@ bool CCollision::ProcessDiscCollision(
 ) {
     ZoneScoped;
 
-    const auto cp       = matBA * tempTriCol.m_vecPoint;
+    const auto cp       = matBA.TransformPoint(tempTriCol.m_vecPoint);
     const auto cpNormal = matBA.TransformVector(tempTriCol.m_vecNormal);
     
     if (std::abs((cpNormal * disk.m_vThickness).ComponentwiseSum()) >= 0.77f ||
@@ -1831,12 +1831,12 @@ bool CCollision::ProcessVerticalLine(
     maxTouchDistance = localMaxTouchDist;
 
     // Transform back from object space
-    cp.m_vecPoint  = transform * cp.m_vecPoint;
+    cp.m_vecPoint  = transform.TransformPoint(cp.m_vecPoint);
     cp.m_vecNormal = transform.TransformVector(cp.m_vecNormal);
 
     if (outColPoly && storedColPoly.valid) {
         for (auto& vtx : storedColPoly.verts) {
-            vtx = transform * vtx; // Transform back from object space
+            vtx = transform.TransformPoint(vtx); // Transform back from object space
         }
         *outColPoly = storedColPoly;
     }

--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1237,7 +1237,7 @@ bool CCollision::ProcessDiscCollision(
     ZoneScoped;
 
     const auto cp       = matBA * tempTriCol.m_vecPoint;
-    const auto cpNormal = Multiply3x3(matBA, tempTriCol.m_vecNormal);
+    const auto cpNormal = Multiply3x3_MV(matBA, tempTriCol.m_vecNormal);
     
     if (std::abs((cpNormal * disk.m_vThickness).ComponentwiseSum()) >= 0.77f ||
         std::abs((((cp - disk.m_vecCenter) * disk.m_vThickness).ComponentwiseSum()) >= disk.m_fThickness)
@@ -1757,7 +1757,7 @@ bool CCollision::ProcessLineOfSight(const CColLine& lnws, const CMatrix& transfo
 
     if (localMinTouchDist < maxTouchDistance) {
         colPoint.m_vecPoint = MultiplyMatrixWithVector(transform, colPoint.m_vecPoint);
-        colPoint.m_vecNormal = Multiply3x3(transform, colPoint.m_vecNormal);
+        colPoint.m_vecNormal = Multiply3x3_MV(transform, colPoint.m_vecNormal);
         maxTouchDistance = localMinTouchDist;
         return true;
     }
@@ -1832,7 +1832,7 @@ bool CCollision::ProcessVerticalLine(
 
     // Transform back from object space
     cp.m_vecPoint  = transform * cp.m_vecPoint;
-    cp.m_vecNormal = Multiply3x3(transform, cp.m_vecNormal);
+    cp.m_vecNormal = Multiply3x3_MV(transform, cp.m_vecNormal);
 
     if (outColPoly && storedColPoly.valid) {
         for (auto& vtx : storedColPoly.verts) {

--- a/source/game_sa/Collision/Sphere.cpp
+++ b/source/game_sa/Collision/Sphere.cpp
@@ -16,7 +16,7 @@ bool CSphere::IsPointWithin(const CVector& p) const {
 
 // NOTSA
 void CSphere::DrawWireFrame(CRGBA color, const CMatrix& transform) const {
-    const CVector center = transform * m_vecCenter;
+    const CVector center = transform.TransformPoint(m_vecCenter);
  
     CVector v13 = center;
     v13.z += m_fRadius;
@@ -48,9 +48,9 @@ void CSphere::DrawWireFrame(CRGBA color, const CMatrix& transform) const {
 }
 
 auto CSphere::GetTransformed(const CMatrix& transform) const -> CSphere {
-    return { transform * m_vecCenter, m_fRadius };
+    return { transform.TransformPoint(m_vecCenter), m_fRadius };
 }
 
 auto TransformObject(const CSphere& sp, const CMatrix& transform) -> CSphere {
-    return { transform * sp.m_vecCenter, sp.m_fRadius };
+    return { transform.TransformPoint(sp.m_vecCenter), sp.m_fRadius };
 }

--- a/source/game_sa/Core/Matrix.cpp
+++ b/source/game_sa/Core/Matrix.cpp
@@ -528,14 +528,10 @@ CMatrix operator*(const CMatrix& a, const CMatrix& b)
     return result;
 }
 
-CVector operator*(const CMatrix& a, const CVector& b)
-{
-    CVector result;
-    result.x = a.m_pos.x + a.m_right.x * b.x + a.m_forward.x * b.y + a.m_up.x * b.z;
-    result.y = a.m_pos.y + a.m_right.y * b.x + a.m_forward.y * b.y + a.m_up.y * b.z;
-    result.z = a.m_pos.z + a.m_right.z * b.x + a.m_forward.z * b.y + a.m_up.z * b.z;
-    return result;
+CVector operator*(const CMatrix& a, const CVector& b) {
+    return a.TransformPoint(b);
 }
+
 CMatrix operator+(const CMatrix& a, const CMatrix& b)
 {
     CMatrix result;

--- a/source/game_sa/Core/Matrix.cpp
+++ b/source/game_sa/Core/Matrix.cpp
@@ -55,7 +55,7 @@ void CMatrix::InjectHooks()
     RH_ScopedInstall(operator+=, 0x59ADF0);
     RH_ScopedInstall(operator*=, 0x411A80);
     RH_ScopedGlobalOverloadedInstall(operator*, "Mat", 0x59BE30, CMatrix(*)(const CMatrix&, const CMatrix&));
-    RH_ScopedGlobalOverloadedInstall(operator*, "Vec", 0x59C890, CVector(*)(const CMatrix&, const CVector&));
+    //RH_ScopedGlobalOverloadedInstall(operator*, "Vec", 0x59C890, CVector(*)(const CMatrix&, const CVector&));
     RH_ScopedGlobalOverloadedInstall(operator+, "", 0x59BFA0, CMatrix(*)(const CMatrix&, const CMatrix&));
     RH_ScopedGlobalOverloadedInstall(Invert, "1", 0x59B920, CMatrix&(*)(CMatrix&, CMatrix&));
     RH_ScopedGlobalOverloadedInstall(Invert, "2", 0x59BDD0, CMatrix(*)(const CMatrix&));
@@ -244,30 +244,30 @@ void CMatrix::RotateX(float angle)
 {
     auto rotMat = CMatrix();
     rotMat.SetRotateX(angle);
-    m_right =   rotMat * m_right;
-    m_forward = rotMat * m_forward;
-    m_up =      rotMat * m_up;
-    m_pos =     rotMat * m_pos;
+    m_right =   rotMat.TransformVector(m_right);
+    m_forward = rotMat.TransformVector(m_forward);
+    m_up =      rotMat.TransformVector(m_up);
+    m_pos =     rotMat.TransformVector(m_pos);
 }
 
 void CMatrix::RotateY(float angle)
 {
     auto rotMat = CMatrix();
     rotMat.SetRotateY(angle);
-    m_right =   rotMat * m_right;
-    m_forward = rotMat * m_forward;
-    m_up =      rotMat * m_up;
-    m_pos =     rotMat * m_pos;
+    m_right =   rotMat.TransformVector(m_right);
+    m_forward = rotMat.TransformVector(m_forward);
+    m_up =      rotMat.TransformVector(m_up);
+    m_pos =     rotMat.TransformVector(m_pos);
 }
 
 void CMatrix::RotateZ(float angle)
 {
     auto rotMat = CMatrix();
     rotMat.SetRotateZ(angle);
-    m_right =   rotMat * m_right;
-    m_forward = rotMat * m_forward;
-    m_up =      rotMat * m_up;
-    m_pos =     rotMat * m_pos;
+    m_right =   rotMat.TransformVector(m_right);
+    m_forward = rotMat.TransformVector(m_forward);
+    m_up =      rotMat.TransformVector(m_up);
+    m_pos =     rotMat.TransformVector(m_pos);
 }
 
 // rotate on 3 axes
@@ -275,10 +275,10 @@ void CMatrix::Rotate(CVector rotation)
 {
     auto rotMat = CMatrix();
     rotMat.SetRotate(rotation.x, rotation.y, rotation.z);
-    m_right =   rotMat * m_right;
-    m_forward = rotMat * m_forward;
-    m_up =      rotMat * m_up;
-    m_pos =     rotMat * m_pos;
+    m_right =   rotMat.TransformVector(m_right);
+    m_forward = rotMat.TransformVector(m_forward);
+    m_up =      rotMat.TransformVector(m_up);
+    m_pos =     rotMat.TransformVector(m_pos);
 }
 
 void CMatrix::Reorthogonalise()

--- a/source/game_sa/Core/Matrix.cpp
+++ b/source/game_sa/Core/Matrix.cpp
@@ -480,8 +480,7 @@ void CMatrix::ConvertFromEulerAngles(float x, float y, float z, uint32 uiFlags)
         fArr[iInd3][iInd1] = -(fCosZ*fSinY);
         fArr[iInd3][iInd2] =   fCosX*fSinZ  + fCosY*fCosZ*fSinX;
         fArr[iInd3][iInd3] = -(fSinX*fSinZ) + fCosX*fCosY*fCosZ;
-    }
-    else { // Use Tait-Bryan angles
+    } else { // Use Tait-Bryan angles
         fArr[iInd1][iInd1] =   fCosY*fCosZ;
         fArr[iInd1][iInd2] = -(fCosX*fSinZ) + fCosZ*fSinX*fSinY;
         fArr[iInd1][iInd3] =   fSinX*fSinZ  + fCosX*fCosZ*fSinY;
@@ -549,25 +548,13 @@ CMatrix operator+(const CMatrix& a, const CMatrix& b)
 
 CMatrix& Invert(CMatrix& in, CMatrix& out)
 {
-    out.GetPosition().Set(0.0F, 0.0F, 0.0F);
-
-    out.GetRight().Set(in.GetRight().x, in.GetForward().x, in.GetUp().x);
-    out.GetForward().Set(in.GetRight().y, in.GetForward().y, in.GetUp().y);
-    out.GetUp().Set(in.GetRight().z, in.GetForward().z, in.GetUp().z);
-
-    out.GetPosition() += in.GetPosition().x * out.GetRight();
-    out.GetPosition() += in.GetPosition().y * out.GetForward();
-    out.GetPosition() += in.GetPosition().z * out.GetUp();
-    out.GetPosition() *= -1.0F;
-
+    out = in.Inverted();
     return out;
 }
 
 CMatrix Invert(const CMatrix& in)
 {
-    CMatrix result;
-    Invert(const_cast<CMatrix&>(in), result); // const cast necessary because it's fucked - but it wont be modified.
-    return result;
+    return in.Inverted();
 }
 
 CMatrix Lerp(CMatrix from, CMatrix to, float t) {

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -184,7 +184,7 @@ public:
     /*!
      * @notsa
      * @brief Transform the vector using the inverse of this Matrix
-     * @brief Use this instead of `Multiply3x3` (0x59C790)
+     * @brief Use this instead of `Multiply3x3(_MV)` (0x59C790)
      * @param pt The vector (direction) to transform
      */
     CVector InverseTransformVector(CVector v) const {

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -165,6 +165,10 @@ public:
      * @param pt The vector (direction) to transform
      */
     CVector TransformVector(CVector v) const {
+        // Inlined:
+        // > m_right.x * v.x + m_forward.x * v.y + m_up.x * v.z,
+        // > m_right.y * v.x + m_forward.y * v.y + m_up.y * v.z,
+        // > m_right.z * v.x + m_forward.z * v.y + m_up.z * v.z,
         return v.x * m_right + v.y * m_forward + v.z * m_up;
     }
 
@@ -180,11 +184,14 @@ public:
     /*!
      * @notsa
      * @brief Transform the vector using the inverse of this Matrix
+     * @brief Use this instead of `Multiply3x3` (0x59C790)
      * @param pt The vector (direction) to transform
      */
     CVector InverseTransformVector(CVector v) const {
         // I got this by transposing the rotation matrix, and then applying a transform...
         // So I ended up with dot products (which make sense if you think about it)
+        // `Inverted().TransformPoint(v)`
+
         return { m_right.Dot(v), m_forward.Dot(v), m_up.Dot(v) }; 
     }
 

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -21,7 +21,9 @@ enum eMatrixEulerFlags : uint32 {
     ORDER_YXZ = 0x0C,
     ORDER_ZXY = 0x10,
     ORDER_ZYX = 0x14,
-    _ORDER_MASK = 0x1C,
+
+    // Special combined masks, do not use
+    _ORDER_MASK = ORDER_XYZ | ORDER_XZY | ORDER_YZX | ORDER_YXZ | ORDER_ZXY | ORDER_ZYX,
     _ORDER_NEEDS_SWAP = 0x4
 };
 
@@ -129,6 +131,62 @@ public:
     void ForceUpVector(CVector vecUp);
     void ConvertToEulerAngles(float* pX, float* pY, float* pZ, uint32 uiFlags);
     void ConvertFromEulerAngles(float x, float y, float z, uint32 uiFlags);
+
+    /*!
+     * @notsa
+     * @brief Calculate the inverse of this matrix
+     */
+    CMatrix Inverted() const {
+        CMatrix o;
+
+        // Transpose rotation
+        o.m_right   = CVector{ m_right.x, m_forward.x, m_up.x };
+        o.m_forward = CVector{ m_right.y, m_forward.y, m_up.y };
+        o.m_up      = CVector{ m_right.z, m_forward.z, m_up.z };
+
+        // Transform translation using the calculated rotation matrix
+        o.m_pos     = -o.TransformVector(m_pos);
+
+        return o;
+    }
+
+    /*!
+     * @notsa
+     * @brief Transform a point (position) - will take into account translation part of the Matrix.
+     * @param pt The position (point) to transform
+    */
+    CVector TransformPoint(CVector pt) const {
+        return TransformVector(pt) + m_pos;
+    }
+
+    /*!
+     * @notsa
+     * @brief Transform a direction vector - will not take into account translation part of the Matrix.
+     * @param pt The vector (direction) to transform
+     */
+    CVector TransformVector(CVector v) const {
+        return v.x * m_right + v.y * m_forward + v.z * m_up;
+    }
+
+    /*!
+     * @notsa
+     * @brief Transform a point (position) using the inverse of the matrix - Will take into account translation part of the matrix.
+     * @param pt The position (point) to transform
+     */
+    CVector InverseTransformPoint(CVector pt) const {
+        return InverseTransformVector(pt - m_pos);
+    }
+
+    /*!
+     * @notsa
+     * @brief Transform the vector using the inverse of this Matrix
+     * @param pt The vector (direction) to transform
+     */
+    CVector InverseTransformVector(CVector v) const {
+        // I got this by transposing the rotation matrix, and then applying a transform...
+        // So I ended up with dot products (which make sense if you think about it)
+        return { m_right.Dot(v), m_forward.Dot(v), m_up.Dot(v) }; 
+    }
 
     void operator=(const CMatrix& right);
     void operator+=(const CMatrix& right);

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -153,6 +153,7 @@ public:
     /*!
      * @notsa
      * @brief Transform a point (position) - will take into account translation part of the Matrix.
+     * @brief Use instead of `MultiplyMatrixWithVector` (0x59C890)
      * @param pt The position (point) to transform
     */
     CVector TransformPoint(CVector pt) const {
@@ -175,6 +176,7 @@ public:
     /*!
      * @notsa
      * @brief Transform a point (position) using the inverse of the matrix - Will take into account translation part of the matrix.
+     * @brief Use this instead of `Multiply3x3(_VM)` (0x59C810)
      * @param pt The position (point) to transform
      */
     CVector InverseTransformPoint(CVector pt) const {

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -246,18 +246,13 @@ private:
     friend class CVector; // So Vector methods have access to private fields of matrix whitout accessor methods, for more readable code
     friend class CVector2D;
     friend CMatrix operator*(const CMatrix& a, const CMatrix& b);
-    // static CMatrix* impl_operatorMul(CMatrix* out, const CMatrix& a, const CMatrix& b);
-
     friend CVector operator*(const CMatrix& a, const CVector& b);
-    // static CVector* impl_operatorMul(CVector* out, const CMatrix& a, const CVector& b);
-
     friend CMatrix operator+(const CMatrix& a, const CMatrix& b);
-    // static CMatrix* impl_operatorAdd(CMatrix* out, const CMatrix& a, const CMatrix& b);
 };
 VALIDATE_SIZE(CMatrix, 0x48);
 
 CMatrix operator*(const CMatrix& a, const CMatrix& b);
-CVector operator*(const CMatrix& a, const CVector& b);
+[[deprecated]] CVector operator*(const CMatrix& a, const CVector& b);
 CMatrix operator+(const CMatrix& a, const CMatrix& b);
 
 CMatrix& Invert(CMatrix& in, CMatrix& out);

--- a/source/game_sa/Core/Vector.cpp
+++ b/source/game_sa/Core/Vector.cpp
@@ -207,22 +207,3 @@ float DotProduct2D(const CVector& v1, const CVector& v2)
 {
     return v1.y * v2.y + v1.x * v2.x;
 }
-
-// NOTE: This function doesn't add m.GetPosition() like
-//       MultiplyMatrixWithVector @ 0x59C890 does.
-CVector Multiply3x3_MV(const CMatrix& m, const CVector& v) {
-    NOTSA_UNREACHABLE("Use `m.TransformVector(v)` instead");
-}
-
-// vector by matrix mult, resulting in a vector where each component is the dot product of the in vector and a matrix direction
-CVector Multiply3x3_VM(const CVector& v, const CMatrix& m) {
-    NOTSA_UNREACHABLE("Use `m.InverseTransformVector(v)` m");
-}
-
-CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) {
-    return mat.TransformPoint(vec);
-}
-
-CVector MultiplyMatrixWithVector(CMatrix& m, const CVector& v) {
-    return m.TransformPoint(v);
-}

--- a/source/game_sa/Core/Vector.cpp
+++ b/source/game_sa/Core/Vector.cpp
@@ -210,13 +210,13 @@ float DotProduct2D(const CVector& v1, const CVector& v2)
 
 // NOTE: This function doesn't add m.GetPosition() like
 //       MultiplyMatrixWithVector @ 0x59C890 does.
-CVector Multiply3x3(const CMatrix& m, const CVector& v) {
-    return m.TransformVector(v);
+CVector Multiply3x3_MV(const CMatrix& m, const CVector& v) {
+    NOTSA_UNREACHABLE("Use `m.TransformVector(v)` instead");
 }
 
 // vector by matrix mult, resulting in a vector where each component is the dot product of the in vector and a matrix direction
-CVector Multiply3x3(const CVector& v, const CMatrix& constm) {
-    return constm.InverseTransformVector(v);
+CVector Multiply3x3_VM(const CVector& v, const CMatrix& m) {
+    NOTSA_UNREACHABLE("Use `m.InverseTransformVector(v)` m");
 }
 
 CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) {

--- a/source/game_sa/Core/Vector.cpp
+++ b/source/game_sa/Core/Vector.cpp
@@ -162,18 +162,12 @@ void CVector::operator /= (float divisor)
     z /= divisor;
 }
 
-void CVector::FromMultiply(const CMatrix& matrix, const CVector& vector)
-{
-    x = matrix.m_pos.x + matrix.m_right.x * vector.x + matrix.m_forward.x * vector.y + matrix.m_up.x * vector.z;
-    y = matrix.m_pos.y + matrix.m_right.y * vector.x + matrix.m_forward.y * vector.y + matrix.m_up.y * vector.z;
-    z = matrix.m_pos.z + matrix.m_right.z * vector.x + matrix.m_forward.z * vector.y + matrix.m_up.z * vector.z;
+void CVector::FromMultiply(const CMatrix& matrix, const CVector& vector) {
+    *this = matrix.TransformPoint(vector);
 }
 
-void CVector::FromMultiply3x3(const CMatrix& matrix, const CVector& vector)
-{
-    x = matrix.m_right.x * vector.x + matrix.m_forward.x * vector.y + matrix.m_up.x * vector.z;
-    y = matrix.m_right.y * vector.x + matrix.m_forward.y * vector.y + matrix.m_up.y * vector.z;
-    z = matrix.m_right.z * vector.x + matrix.m_forward.z * vector.y + matrix.m_up.z * vector.z;
+void CVector::FromMultiply3x3(const CMatrix& matrix, const CVector& vector) {
+    *this = matrix.TransformVector(vector);
 }
 
 CVector CVector::Average(const CVector* begin, const CVector* end) {
@@ -190,7 +184,7 @@ float CVector::Heading(bool limitAngle) const {
 
 CVector* CrossProduct(CVector* out, CVector* a, CVector* b)
 {
-    *out = a->Cross(b);
+    *out = a->Cross(*b);
     return out;
 }
 
@@ -216,29 +210,19 @@ float DotProduct2D(const CVector& v1, const CVector& v2)
 
 // NOTE: This function doesn't add m.GetPosition() like
 //       MultiplyMatrixWithVector @ 0x59C890 does.
-CVector Multiply3x3(const CMatrix& constm, const CVector& v) {
-    auto& m = const_cast<CMatrix&>(constm);
-    return {
-        m.GetRight().x * v.x + m.GetForward().x * v.y + m.GetUp().x * v.z,
-        m.GetRight().y * v.x + m.GetForward().y * v.y + m.GetUp().y * v.z,
-        m.GetRight().z * v.x + m.GetForward().z * v.y + m.GetUp().z * v.z,
-    };
+CVector Multiply3x3(const CMatrix& m, const CVector& v) {
+    return m.TransformVector(v);
 }
 
 // vector by matrix mult, resulting in a vector where each component is the dot product of the in vector and a matrix direction
 CVector Multiply3x3(const CVector& v, const CMatrix& constm) {
-    auto& m = const_cast<CMatrix&>(constm);
-    return {
-        DotProduct(m.GetRight(), v),
-        DotProduct(m.GetForward(), v),
-        DotProduct(m.GetUp(), v)
-    };
+    return constm.InverseTransformVector(v);
 }
 
 CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) {
-    return const_cast<CMatrix&>(mat).GetPosition() + Multiply3x3(const_cast<CMatrix&>(mat), vec);
+    return mat.TransformPoint(vec);
 }
 
 CVector MultiplyMatrixWithVector(CMatrix& m, const CVector& v) {
-    return m.GetPosition() + Multiply3x3(m, v);
+    return m.TransformPoint(v);
 }

--- a/source/game_sa/Core/Vector.h
+++ b/source/game_sa/Core/Vector.h
@@ -267,6 +267,6 @@ static CVector ProjectVector(const CVector& what, const CVector& onto) {
     return onto * (DotProduct(what, onto) / onto.SquaredMagnitude());
 }
 
-[[deprecated]] CVector Multiply3x3_MV(const CMatrix& m, const CVector& v) { NOTSA_UNREACHABLE("Use `m.TransformVector(v)` instead"); }
-[[deprecated]] CVector Multiply3x3_VM(const CVector& v, const CMatrix& m) { NOTSA_UNREACHABLE("Use `m.InverseTransformVector(v)` m"); }
-[[deprecated]] CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) { NOTSA_UNREACHABLE("Use `m.TransformPoint(v)` instead"); }
+[[deprecated]] inline CVector Multiply3x3_MV(const CMatrix& m, const CVector& v) { NOTSA_UNREACHABLE("Use `m.TransformVector(v)` instead"); }
+[[deprecated]] inline CVector Multiply3x3_VM(const CVector& v, const CMatrix& m) { NOTSA_UNREACHABLE("Use `m.InverseTransformVector(v)` m"); }
+[[deprecated]] inline CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) { NOTSA_UNREACHABLE("Use `m.TransformPoint(v)` instead"); }

--- a/source/game_sa/Core/Vector.h
+++ b/source/game_sa/Core/Vector.h
@@ -18,9 +18,8 @@ public:
     constexpr CVector() = default;
     constexpr CVector(float X, float Y, float Z) : RwV3d{ X, Y, Z } {}
     constexpr CVector(RwV3d rwVec) { x = rwVec.x; y = rwVec.y; z = rwVec.z; }
-    constexpr CVector(const CVector* rhs) { x = rhs->x; y = rhs->y; z = rhs->z; }
+    constexpr CVector(const CVector* rhs) { x = rhs->x; y = rhs->y; z = rhs->z; } // TODO: Remove
     constexpr explicit CVector(float value) { x = y = z = value; }
-
     explicit CVector(const CVector2D& v2, float z = 0.f);
 
 public:

--- a/source/game_sa/Core/Vector.h
+++ b/source/game_sa/Core/Vector.h
@@ -267,6 +267,6 @@ static CVector ProjectVector(const CVector& what, const CVector& onto) {
     return onto * (DotProduct(what, onto) / onto.SquaredMagnitude());
 }
 
-CVector Multiply3x3_MV(const CMatrix& m, const CVector& v);
-CVector Multiply3x3_VM(const CVector& v, const CMatrix& m);
-CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec);
+[[deprecated]] CVector Multiply3x3_MV(const CMatrix& m, const CVector& v) { NOTSA_UNREACHABLE("Use `m.TransformVector(v)` instead"); }
+[[deprecated]] CVector Multiply3x3_VM(const CVector& v, const CMatrix& m) { NOTSA_UNREACHABLE("Use `m.InverseTransformVector(v)` m"); }
+[[deprecated]] CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec) { NOTSA_UNREACHABLE("Use `m.TransformPoint(v)` instead"); }

--- a/source/game_sa/Core/Vector.h
+++ b/source/game_sa/Core/Vector.h
@@ -267,6 +267,6 @@ static CVector ProjectVector(const CVector& what, const CVector& onto) {
     return onto * (DotProduct(what, onto) / onto.SquaredMagnitude());
 }
 
-CVector Multiply3x3(const CMatrix& m, const CVector& v);
-CVector Multiply3x3(const CVector& v, const CMatrix& m);
+CVector Multiply3x3_MV(const CMatrix& m, const CVector& v);
+CVector Multiply3x3_VM(const CVector& v, const CMatrix& m);
 CVector MultiplyMatrixWithVector(const CMatrix& mat, const CVector& vec);

--- a/source/game_sa/Core/Vector2D.h
+++ b/source/game_sa/Core/Vector2D.h
@@ -15,7 +15,7 @@ class CVector;
 class CVector2D : public RwV2d {
 public:
     constexpr CVector2D() = default;
-    constexpr CVector2D(float XY) : RwV2d{XY, XY} {}
+    constexpr explicit CVector2D(float XY) : RwV2d{XY, XY} {}
     constexpr CVector2D(float X, float Y) : RwV2d{ X, Y } {}
     constexpr CVector2D(const RwV2d& vec2d)     { x = vec2d.x; y = vec2d.y; }
     constexpr CVector2D(const CVector2D& vec2d) { x = vec2d.x; y = vec2d.y; }

--- a/source/game_sa/Cover.cpp
+++ b/source/game_sa/Cover.cpp
@@ -111,7 +111,7 @@ void CCover::FindCoverPointsForThisBuilding(CBuilding* building) {
 
         const auto fTwoPiToChar = 256.0F / TWO_PI;
         const auto ucAngle = static_cast<uint8>(atan2(vedTransformed.x, vedTransformed.y) * fTwoPiToChar);
-        auto vecPoint = building->GetMatrix() * effect->m_pos;
+        auto vecPoint = building->GetMatrix().TransformPoint(effect->m_pos);
         CCover::AddCoverPoint(3, building, &vecPoint, effect->coverPoint.m_nType, ucAngle);
     }
 }

--- a/source/game_sa/Cover.cpp
+++ b/source/game_sa/Cover.cpp
@@ -107,7 +107,7 @@ void CCover::FindCoverPointsForThisBuilding(CBuilding* building) {
             continue;
 
         auto vecDir = CVector(effect->coverPoint.m_vecDirection.x, effect->coverPoint.m_vecDirection.y, 0.0F);
-        const auto vedTransformed = Multiply3x3(building->GetMatrix(), vecDir);
+        const auto vedTransformed = Multiply3x3_MV(building->GetMatrix(), vecDir);
 
         const auto fTwoPiToChar = 256.0F / TWO_PI;
         const auto ucAngle = static_cast<uint8>(atan2(vedTransformed.x, vedTransformed.y) * fTwoPiToChar);

--- a/source/game_sa/Cover.cpp
+++ b/source/game_sa/Cover.cpp
@@ -107,7 +107,7 @@ void CCover::FindCoverPointsForThisBuilding(CBuilding* building) {
             continue;
 
         auto vecDir = CVector(effect->coverPoint.m_vecDirection.x, effect->coverPoint.m_vecDirection.y, 0.0F);
-        const auto vedTransformed = Multiply3x3_MV(building->GetMatrix(), vecDir);
+        const auto vedTransformed = building->GetMatrix().TransformVector(vecDir);
 
         const auto fTwoPiToChar = 256.0F / TWO_PI;
         const auto ucAngle = static_cast<uint8>(atan2(vedTransformed.x, vedTransformed.y) * fTwoPiToChar);

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -1122,7 +1122,7 @@ CVector* CEntity::FindTriggerPointCoors(CVector* outVec, int32 triggerIndex)
     for (int32 iFxInd = 0; iFxInd < mi->m_n2dfxCount; ++iFxInd) {
         auto effect = mi->Get2dEffect(iFxInd);
         if (effect->m_type == e2dEffectType::EFFECT_TRIGGER_POINT && effect->slotMachineIndex.m_nId == triggerIndex) {
-            *outVec = GetMatrix() * effect->m_pos;
+            *outVec = GetMatrix().TransformPoint(effect->m_pos);
             return outVec;
         }
     }
@@ -1172,7 +1172,7 @@ CVector CEntity::TransformFromObjectSpace(const CVector& offset)
 {
     auto result = CVector();
     if (m_matrix) {
-        result = *m_matrix * offset;
+        result = m_matrix->TransformPoint(offset);
         return result;
     }
 
@@ -2454,7 +2454,7 @@ bool CEntity::IsEntityOccluded()
                 bInView = true;
             }
 
-            auto vecDiag1 = GetMatrix() * CVector(bounding.m_vecMin.x, bounding.m_vecMax.y, bounding.m_vecMax.z);
+            auto vecDiag1 = GetMatrix().TransformVector(CVector(bounding.m_vecMin.x, bounding.m_vecMax.y, bounding.m_vecMax.z));
             if (bInView
                 || !CalcScreenCoors(vecDiag1, &vecScreen)
                 || !activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)
@@ -2463,7 +2463,7 @@ bool CEntity::IsEntityOccluded()
                 bInView = true;
             }
 
-            auto vecDiag2 = GetMatrix() * CVector(bounding.m_vecMax.x, bounding.m_vecMin.y, bounding.m_vecMin.z);
+            auto vecDiag2 = GetMatrix().TransformVector(CVector(bounding.m_vecMax.x, bounding.m_vecMin.y, bounding.m_vecMin.z));
             if (!bInView
                 && CalcScreenCoors(vecDiag2, &vecScreen)
                 && activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)
@@ -2478,7 +2478,7 @@ bool CEntity::IsEntityOccluded()
                 if (bounding.GetHeight() <= 30.0F)
                     return true;
 
-                auto vecDiag3 = GetMatrix() * CVector(bounding.m_vecMin.x, bounding.m_vecMin.y, bounding.m_vecMax.z);
+                auto vecDiag3 = GetMatrix().TransformVector(CVector(bounding.m_vecMin.x, bounding.m_vecMin.y, bounding.m_vecMax.z));
                 if (!CalcScreenCoors(vecDiag3, &vecScreen)
                     || !activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)
                     || !activeOccluder.IsPointBehindOccluder(vecDiag3, 0.0F)) {
@@ -2486,7 +2486,7 @@ bool CEntity::IsEntityOccluded()
                     bInView = true;
                 }
 
-                auto vecDiag4 = GetMatrix() * CVector(bounding.m_vecMax.x, bounding.m_vecMin.y, bounding.m_vecMax.z);
+                auto vecDiag4 = GetMatrix().TransformVector(CVector(bounding.m_vecMax.x, bounding.m_vecMin.y, bounding.m_vecMax.z));
                 if (!bInView
                     && CalcScreenCoors(vecDiag4, &vecScreen)
                     && activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -2161,7 +2161,7 @@ void CEntity::ProcessLightsForEntity()
                     static_cast<float>(effect->light.offsetY),
                     static_cast<float>(effect->light.offsetZ)
                 };
-                auto vecLightPos = Multiply3x3(GetMatrix(), lightOffset);
+                auto vecLightPos = Multiply3x3_MV(GetMatrix(), lightOffset);
 
                 auto fDot = DotProduct(vecLightPos, (camPos - vecEffPos));
                 bCanCreateLight = fDot >= 0.0F;

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -2161,7 +2161,7 @@ void CEntity::ProcessLightsForEntity()
                     static_cast<float>(effect->light.offsetY),
                     static_cast<float>(effect->light.offsetZ)
                 };
-                auto vecLightPos = Multiply3x3_MV(GetMatrix(), lightOffset);
+                auto vecLightPos = GetMatrix().TransformVector(lightOffset);
 
                 auto fDot = DotProduct(vecLightPos, (camPos - vecEffPos));
                 bCanCreateLight = fDot >= 0.0F;

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -2437,7 +2437,7 @@ bool CEntity::IsEntityOccluded()
             const auto& bounding = mi->GetColModel()->GetBoundingBox();
             CVector vecScreen;
 
-            auto vecMin = GetMatrix() * bounding.m_vecMin;
+            auto vecMin = GetMatrix().TransformPoint(bounding.m_vecMin);
             if (!CalcScreenCoors(vecMin, &vecScreen)
                 || !activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)
                 || !activeOccluder.IsPointBehindOccluder(vecMin, 0.0F)
@@ -2445,7 +2445,7 @@ bool CEntity::IsEntityOccluded()
                 bInView = true;
             }
 
-            auto vecMax = GetMatrix() * bounding.m_vecMax;
+            auto vecMax = GetMatrix().TransformPoint(bounding.m_vecMax);
             if (bInView
                 || !CalcScreenCoors(vecMax, &vecScreen)
                 || !activeOccluder.IsPointWithinOcclusionArea(vecScreen.x, vecScreen.y, 0.0F)

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -1313,7 +1313,7 @@ void CObject::GrabObjectToCarryWithRope(CPhysical* attachTo) {
 
     auto vecRopePoint = CVector();
     vecRopePoint.z = CRopes::FindPickupHeight(attachTo);
-    vecRopePoint *= *attachTo->m_matrix * vecRopePoint;
+    vecRopePoint *= attachTo->m_matrix->TransformPoint(vecRopePoint);
 
     rope.m_pRopeAttachObject->SetPosn(vecRopePoint);
     rope.m_pRopeAttachObject->m_bUsesCollision = false;
@@ -1402,16 +1402,16 @@ void CObject::ProcessControlLogic() {
         }
 
         if (m_nModelIndex == ModelIndices::MI_MAGNOCRANE) {
-            auto vecRopePoint = *m_matrix * CVector(0.0F, 36.64F, -1.69F);
+            auto vecRopePoint = m_matrix->TransformPoint(CVector(0.0F, 36.64F, -1.69F));
             vecRopePoint.z += fRopeLengthChange;
             CRopes::RegisterRope((uint32)this, static_cast<uint32>(eRopeType::CRANE_MAGNO), vecRopePoint, false, nSegments, 1u, this, 20'000u);
         } else if (m_nModelIndex == ModelIndices::MI_CRANETROLLEY) {
             const auto nRopeType = static_cast<const uint32>(GetPosition().x >= 0 ? eRopeType::CRANE_TROLLEY : eRopeType::WRECKING_BALL);
-            auto vecRopePoint = *m_matrix * CVector(0.0F, 0.0F, 0.0F);
+            auto vecRopePoint = m_matrix->TransformPoint(CVector(0.0F, 0.0F, 0.0F));
             vecRopePoint.z += fRopeLengthChange;
             CRopes::RegisterRope((uint32)this, nRopeType, vecRopePoint, false, nSegments, 1u, this, 20'000u);
         } else {
-            auto vecRopePoint = *m_matrix * CVector(0.0F, 0.0F, 59.0F);
+            auto vecRopePoint = m_matrix->TransformPoint(CVector(0.0F, 0.0F, 59.0F));
             vecRopePoint.z += fRopeLengthChange;
             CRopes::RegisterRope((uint32)this, static_cast<uint32>(eRopeType::QUARRY_CRANE_ARM), vecRopePoint, false, nSegments, 1u, this, 20'000u);
         }

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -475,7 +475,7 @@ uint8 CObject::SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionB
     if (!physicalFlags.bDisableMoveForce) {
         if (physicalFlags.bInfiniteMass) {
             auto cm = CEntity::GetColModel();
-            auto vecMin = Multiply3x3_MV(GetMatrix(), cm->GetBoundingBox().m_vecMin);
+            auto vecMin = GetMatrix().TransformVector(cm->GetBoundingBox().m_vecMin);
             auto vecSpeed = CPhysical::GetSpeed(vecMin);
             const auto fMove = vecSpeed.SquaredMagnitude() * sq(CTimer::GetTimeStep());
             if (fMove >= 0.0225F) // std::pow(0.15F, 2.0F)
@@ -491,11 +491,11 @@ uint8 CObject::SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionB
             auto* cm = GetModelInfo()->GetColModel();
 
             auto vecMin = CVector(0.0F, 0.0F, cm->GetBoundingBox().m_vecMin.z);
-            vecMin = Multiply3x3_MV(GetMatrix(), vecMin);
+            vecMin = GetMatrix().TransformVector(vecMin);
             vecMin = CPhysical::GetSpeed(vecMin);
 
             auto vecMax = CVector(0.0F, 0.0F, cm->GetBoundingBox().m_vecMax.z);
-            vecMax = Multiply3x3_MV(GetMatrix(), vecMax);
+            vecMax = GetMatrix().TransformVector(vecMax);
             vecMax = CPhysical::GetSpeed(vecMax);
 
             auto& vecUsed = vecMin.SquaredMagnitude() >= vecMax.SquaredMagnitude() ? vecMin : vecMax;

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -424,7 +424,7 @@ void CObject::SpecialEntityPreCollisionStuff_Reversed(CPhysical* colPhysical, bo
                         else
                         {
                             Invert(colPhysical->GetMatrix(), tempMat);
-                            if ((tempMat * vecTransformed).z < 0.0F)
+                            if ((tempMat.TransformPoint(vecTransformed)).z < 0.0F)
                             {
                                 bCollidedEntityCollisionIgnored = true;
                                 m_pEntityIgnoredCollision = colPhysical;
@@ -880,7 +880,7 @@ void CObject::Init() {
 }
 
 // 0x59FB50
-void CObject::DoBurnEffect() {
+void CObject::DoBurnEffect() const {
     const auto& box = GetModelInfo()->GetColModel()->GetBoundingBox();
     const auto& vecSize = box.GetSize();
     const auto nUsedSize = static_cast<int32>(vecSize.x * vecSize.y * vecSize.z * m_fBurnDamage / 20.0F);
@@ -891,7 +891,7 @@ void CObject::DoBurnEffect() {
         const auto fRandX = CGeneral::GetRandomNumberInRange(box.m_vecMin.x, box.m_vecMax.x);
         const auto fRandY = CGeneral::GetRandomNumberInRange(box.m_vecMin.y, box.m_vecMax.y);
         const auto fRandZ = CGeneral::GetRandomNumberInRange(box.m_vecMin.z, box.m_vecMax.z);
-        auto vecParticlePos = *m_matrix * CVector(fRandX, fRandY, fRandZ);
+        auto vecParticlePos = m_matrix->TransformPoint(CVector(fRandX, fRandY, fRandZ));
 
         // auto smokePart = FxPrtMult_c() Originally overwritten right after
         auto smokePart = FxPrtMult_c(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F, 0.4F);
@@ -968,7 +968,7 @@ void CObject::ProcessSamSiteBehaviour() {
                 return;
 
             auto vecRocketDir = m_matrix->GetForward() + m_matrix->GetUp();
-            const auto vecSrcPos = *m_matrix * CVector(0.0F, 2.0F, 4.0F);
+            const auto vecSrcPos = m_matrix->TransformPoint(CVector(0.0F, 2.0F, 4.0F));
             CProjectileInfo::AddProjectile(this, eWeaponType::WEAPON_ROCKET_HS, vecSrcPos, 0.0F, &vecRocketDir, targetEntity);
             return;
         }
@@ -1166,7 +1166,7 @@ void CObject::ObjectDamage(float damage, const CVector* fxOrigin, const CVector*
         return;
     }
 
-    auto vecPoint = *m_matrix * m_pObjectInfo->m_vFxOffset;
+    auto vecPoint = m_matrix->TransformPoint(m_pObjectInfo->m_vFxOffset);
     vecPoint += GetPosition();
     auto* fxSystem = g_fxMan.CreateFxSystem(m_pObjectInfo->m_pFxSystemBP, vecPoint, nullptr, false);
     if (fxSystem)
@@ -1195,7 +1195,7 @@ void CObject::Explode() {
     }
 
     if (m_pObjectInfo->m_nFxType == eObjectFxType::PLAY_ON_DESTROYED) {
-        auto vecPoint = *m_matrix * m_pObjectInfo->m_vFxOffset;
+        auto vecPoint = m_matrix->TransformPoint(m_pObjectInfo->m_vFxOffset);
         vecPoint += GetPosition();
         auto* fxSystem = g_fxMan.CreateFxSystem(m_pObjectInfo->m_pFxSystemBP, &vecPoint, nullptr, false);
         if (fxSystem)

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -413,7 +413,7 @@ void CObject::SpecialEntityPreCollisionStuff_Reversed(CPhysical* colPhysical, bo
                         auto tempMat = CMatrix();
                         auto* cm = CEntity::GetColModel();
                         auto vecSize = cm->GetBoundingBox().GetSize();
-                        auto vecTransformed = *m_matrix * vecSize;
+                        auto vecTransformed = m_matrix->TransformPoint(vecSize);
 
                         auto& vecCollidedPos = colPhysical->GetPosition();
                         if (vecTransformed.z < vecCollidedPos.z)

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -475,7 +475,7 @@ uint8 CObject::SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionB
     if (!physicalFlags.bDisableMoveForce) {
         if (physicalFlags.bInfiniteMass) {
             auto cm = CEntity::GetColModel();
-            auto vecMin = Multiply3x3(GetMatrix(), cm->GetBoundingBox().m_vecMin);
+            auto vecMin = Multiply3x3_MV(GetMatrix(), cm->GetBoundingBox().m_vecMin);
             auto vecSpeed = CPhysical::GetSpeed(vecMin);
             const auto fMove = vecSpeed.SquaredMagnitude() * sq(CTimer::GetTimeStep());
             if (fMove >= 0.0225F) // std::pow(0.15F, 2.0F)
@@ -491,11 +491,11 @@ uint8 CObject::SpecialEntityCalcCollisionSteps_Reversed(bool& bProcessCollisionB
             auto* cm = GetModelInfo()->GetColModel();
 
             auto vecMin = CVector(0.0F, 0.0F, cm->GetBoundingBox().m_vecMin.z);
-            vecMin = Multiply3x3(GetMatrix(), vecMin);
+            vecMin = Multiply3x3_MV(GetMatrix(), vecMin);
             vecMin = CPhysical::GetSpeed(vecMin);
 
             auto vecMax = CVector(0.0F, 0.0F, cm->GetBoundingBox().m_vecMax.z);
-            vecMax = Multiply3x3(GetMatrix(), vecMax);
+            vecMax = Multiply3x3_MV(GetMatrix(), vecMax);
             vecMax = CPhysical::GetSpeed(vecMax);
 
             auto& vecUsed = vecMin.SquaredMagnitude() >= vecMax.SquaredMagnitude() ? vecMin : vecMax;

--- a/source/game_sa/Entity/Object/Object.h
+++ b/source/game_sa/Entity/Object/Object.h
@@ -136,7 +136,7 @@ public:
     void     ResetDoorAngle();
     void     LockDoor();
     void     Init();
-    void     DoBurnEffect();
+    void     DoBurnEffect() const;
     void     GetLightingFromCollisionBelow();
     void     ProcessSamSiteBehaviour();
     void     ProcessTrainCrossingBehaviour();

--- a/source/game_sa/Entity/Physical.cpp
+++ b/source/game_sa/Entity/Physical.cpp
@@ -4494,7 +4494,7 @@ bool CPhysical::ProcessCollisionSectorList(int32 sectorX, int32 sectorY)
                                 } else {
                                     CMatrix invertedMatrix;
                                     invertedMatrix = Invert(entity->GetMatrix(), invertedMatrix);
-                                    if ((invertedMatrix * boundBoxPos).z < 0.0f)
+                                    if ((invertedMatrix.TransformPoint(boundBoxPos)).z < 0.0f)
                                         bObjectDamage = true;
                                 }
 

--- a/source/game_sa/Entity/Physical.cpp
+++ b/source/game_sa/Entity/Physical.cpp
@@ -745,7 +745,7 @@ void CPhysical::ApplyTurnForce(CVector force, CVector point)
     {
         CVector vecCentreOfMassMultiplied{};
         if (!physicalFlags.bInfiniteMass)
-            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce) {
             point.z = 0.0f;
@@ -772,7 +772,7 @@ void CPhysical::ApplyForce(CVector vecForce, CVector point, bool bUpdateTurnSpee
         if (physicalFlags.bInfiniteMass)
             fTurnMass += m_vecCentreOfMass.z * m_fMass * m_vecCentreOfMass.z * 0.5f;
         else
-            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce) {
             point.z = 0.0f;
@@ -789,7 +789,7 @@ CVector CPhysical::GetSpeed(CVector point)
 {
     CVector vecCentreOfMassMultiplied{};
     if (!physicalFlags.bInfiniteMass)
-        vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+        vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
     CVector distance = point - vecCentreOfMassMultiplied;
     CVector vecTurnSpeed = m_vecTurnSpeed + m_vecFrictionTurnSpeed;
@@ -833,7 +833,7 @@ void CPhysical::ApplyTurnSpeed()
         GetUp() += vecCrossProduct;
         if (!physicalFlags.bInfiniteMass && !physicalFlags.bDisableMoveForce) {
             CVector vecNegativeCentreOfMass = m_vecCentreOfMass * -1.0f;
-            CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), vecNegativeCentreOfMass);
+            CVector vecCentreOfMassMultiplied = GetMatrix().TransformVector(vecNegativeCentreOfMass);
             GetPosition() += CrossProduct(vecTurnSpeedTimeStep, vecCentreOfMassMultiplied);
         }
     }
@@ -845,7 +845,7 @@ void CPhysical::ApplyGravity()
     if (physicalFlags.bApplyGravity && !physicalFlags.bDisableMoveForce) {
         if (physicalFlags.bInfiniteMass) {
             float fMassTimeStep = CTimer::GetTimeStep() * m_fMass;
-            CVector point = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            CVector point = GetMatrix().TransformVector(m_vecCentreOfMass);
             CVector force (0.0f, 0.0f, fMassTimeStep * -0.008f);
             ApplyForce(force, point, true);
         }
@@ -897,7 +897,7 @@ void CPhysical::ApplyFrictionForce(CVector vecMoveForce, CVector point)
         if (physicalFlags.bInfiniteMass)
             fTurnMass += m_vecCentreOfMass.z * m_fMass * m_vecCentreOfMass.z * 0.5f;
         else
-            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce)
         {
@@ -1023,7 +1023,7 @@ bool CPhysical::ApplyCollision(CEntity* entity, CColPoint& colPoint, float& dama
         float fSpeedDotProduct = DotProduct(&vecMoveDirection, &vecSpeed);
         if (fSpeedDotProduct < 0.0f)
         {
-            CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            CVector vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
             CVector vecDifference = vecDistanceToPoint - vecCentreOfMassMultiplied;
             CVector vecSpeedCrossProduct = CrossProduct(vecDifference, vecMoveDirection);
             float fSquaredMagnitude = vecMoveDirection.SquaredMagnitude();
@@ -1087,7 +1087,7 @@ bool CPhysical::ApplySoftCollision(CEntity* entity, CColPoint& colPoint, float& 
     }
 
     float fSpeedDotProduct = DotProduct(&vecSpeed, &vecMoveDirection);
-    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {
@@ -1205,7 +1205,7 @@ bool CPhysical::ApplySpringDampening(float fDampingForce, float fSpringForceDamp
             fDampingSpeed = -fCollisionPointSpeedDotProduct;
     }
 
-    CVector center = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector center = GetMatrix().TransformVector(m_vecCentreOfMass);
     CVector distance = collisionPoint - center;
     float fSpringForceDamping = GetMass(distance, direction) * fDampingSpeed;
     fSpringForceDampingLimit = fabs(fSpringForceDampingLimit) * DAMPING_LIMIT_OF_SPRING_FORCE;
@@ -1530,7 +1530,7 @@ bool CPhysical::ApplyCollisionAlt(CPhysical* entity, CColPoint& colPoint, float&
         return false;
     }
 
-    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
     if (physicalFlags.bInfiniteMass)
     {
         vecCentreOfMassMultiplied = CVector(0.0f, 0.0f, 0.0f);
@@ -1680,7 +1680,7 @@ bool CPhysical::ApplyCollisionAlt(CPhysical* entity, CColPoint& colPoint, float&
             outVecMoveSpeed += vecSpeed;
         }
 
-        vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+        vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
         float fTurnMass = m_fTurnMass;
         CVector vecDifference = vecDistanceToPointFromThis - vecCentreOfMassMultiplied; // todo: shadow var
         CVector vecCrossProduct = CrossProduct(vecDifference, vecMoveSpeed);            // todo: shadow var
@@ -1748,7 +1748,7 @@ bool CPhysical::ApplyFriction(float fFriction, CColPoint& colPoint)
 
     CVector vecMoveDirection = vecSpeedDifference / fMoveSpeedMagnitude;
 
-    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
     CVector vecDifference = vecDistanceToPointFromThis - vecCentreOfMassMultiplied;
     CVector vecSpeedCrossProduct = CrossProduct(vecDifference, vecMoveDirection);
     float squaredMagnitude = vecSpeedCrossProduct.SquaredMagnitude();
@@ -1846,7 +1846,7 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
         float fEntitySpeedMagnitude = vecEntitySpeedDifference.Magnitude();
 
         CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
-        CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
+        CVector vecEntityCentreOfMassMultiplied = entity->GetMatrix().TransformVector(entity->m_vecCentreOfMass);
         CVector vecEntityDifference = vecDistanceToPoint - vecEntityCentreOfMassMultiplied;
         CVector vecEntitySpeedCrossProduct = CrossProduct(vecEntityDifference, vecMoveDirection);
         float squaredMagnitude = vecEntitySpeedCrossProduct.SquaredMagnitude();
@@ -1902,14 +1902,14 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
 
         CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
 
-        CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+        CVector vecThisCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
         CVector vecThisDifference = vecDistanceToPointFromThis - vecThisCentreOfMassMultiplied;
         CVector vecThisSpeedCrossProduct = CrossProduct(vecThisDifference, vecMoveDirection);
         float squaredMagnitude = vecThisSpeedCrossProduct.SquaredMagnitude();
         float fThisCollisionMass = 1.0f / (squaredMagnitude / m_fTurnMass + 1.0f / m_fMass);
 
-        CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
+        CVector vecEntityCentreOfMassMultiplied = entity->GetMatrix().TransformVector(entity->m_vecCentreOfMass);
 
         CVector vecEntityDifference = vecDistanceToPoint - vecEntityCentreOfMassMultiplied;
         CVector vecEntitySpeedCrossProduct = CrossProduct(vecEntityDifference, vecMoveDirection);
@@ -1959,7 +1959,7 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
 
     CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
 
     CVector vecThisDifference = vecDistanceToPointFromThis - vecThisCentreOfMassMultiplied;
     CVector vecThisSpeedCrossProduct = CrossProduct(vecThisDifference, vecMoveDirection);
@@ -2344,7 +2344,7 @@ void CPhysical::PositionAttachedEntity()
         CVector vecMoveSpeedDifference = vecMoveSpeed - m_vecMoveSpeed;
         m_vecMoveSpeed = vecMoveSpeed;
         CVector vecForce = vecMoveSpeedDifference * m_fMass * -1.0f;
-        CVector vecCenterOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+        CVector vecCenterOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
         ApplyForce(vecForce, vecCenterOfMassMultiplied, true);
         if (m_pAttachedTo->IsVehicle() || m_pAttachedTo->IsObject()) {
             if (m_pAttachedTo->m_bUsesCollision && !m_pAttachedTo->physicalFlags.bDisableCollisionForce) {
@@ -2690,8 +2690,8 @@ bool CPhysical::ApplyCollision(CEntity* theEntity, CColPoint& colPoint, float& t
         bThisPedIsStandingOnEntity = false;
     }
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
-    CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
+    CVector vecEntityCentreOfMassMultiplied = entity->GetMatrix().TransformVector(entity->m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {
@@ -3426,8 +3426,8 @@ bool CPhysical::ApplySoftCollision(CPhysical* physical, CColPoint& colPoint, flo
         bThisPedIsStandingOnEntity = false;
     }
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
-    CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(physical->GetMatrix(), physical->m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = GetMatrix().TransformVector(m_vecCentreOfMass);
+    CVector vecEntityCentreOfMassMultiplied = physical->GetMatrix().TransformVector(physical->m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {

--- a/source/game_sa/Entity/Physical.cpp
+++ b/source/game_sa/Entity/Physical.cpp
@@ -319,8 +319,8 @@ void CPhysical::ProcessCollision() {
 
                 CColPoint* wheelColPoint = &wheelsColPoints[collisionIndex];
                 CColLine* colLine = &colData->m_pLines[collisionIndex];
-                CVector vecColLinePosStart = *m_matrix * colLine->m_vecStart;
-                CVector vecColLinePosEnd = *m_matrix * colLine->m_vecEnd;
+                CVector vecColLinePosStart = m_matrix->TransformPoint(colLine->m_vecStart);
+                CVector vecColLinePosEnd = m_matrix->TransformPoint(colLine->m_vecEnd);
                 wheelColPoint->m_vecNormal = CVector(0.0f, 0.0f, 1.0f);
                 wheelColPoint->m_nSurfaceTypeA = SURFACE_WHEELBASE;
                 wheelColPoint->m_nSurfaceTypeB = SURFACE_TARMAC;
@@ -2188,7 +2188,7 @@ bool CPhysical::ProcessShiftSectorList(int32 sectorX, int32 sectorY)
 // 0x546DB0
 void CPhysical::PlacePhysicalRelativeToOtherPhysical(CPhysical* relativeToPhysical, CPhysical* physicalToPlace, CVector offset)
 {
-    CVector vecRelativePosition = *relativeToPhysical->m_matrix * offset;
+    CVector vecRelativePosition = relativeToPhysical->m_matrix->TransformPoint(offset);
     vecRelativePosition += (CTimer::GetTimeStep() * 0.9f) * relativeToPhysical->m_vecMoveSpeed;
     CWorld::Remove(physicalToPlace);
     *(CMatrix*)physicalToPlace->m_matrix = *relativeToPhysical->m_matrix;

--- a/source/game_sa/Entity/Physical.cpp
+++ b/source/game_sa/Entity/Physical.cpp
@@ -2236,7 +2236,7 @@ void CPhysical::PositionAttachedEntity()
         RtQuatConvertToMatrix((RtQuat*)&m_qAttachedEntityRotation, &rotationMatrix);
         attachedEntityMatrix.UpdateMatrix(&rotationMatrix);
         attachedEntityMatrix = attachedToEntityMatrix * attachedEntityMatrix;
-        CVector vecTranslation = attachedToEntityMatrix * m_vecAttachOffset;
+        CVector vecTranslation = attachedToEntityMatrix.TransformPoint(m_vecAttachOffset);
         attachedEntityMatrix.SetTranslateOnly(vecTranslation);
     }
     else {
@@ -4463,7 +4463,7 @@ bool CPhysical::ProcessCollisionSectorList(int32 sectorX, int32 sectorY)
                             if (entityObject->m_nColDamageEffect >= COL_DAMAGE_EFFECT_SMASH_COMPLETELY) {
                                 CBaseModelInfo* pEntityModelInfo = CModelInfo::GetModelInfo(entity->m_nModelIndex);
                                 CColModel* colModel = pEntityModelInfo->GetColModel();
-                                CVector boundBoxPos = entity->GetMatrix() * colModel->m_boundBox.GetSize();
+                                CVector boundBoxPos = entity->GetMatrix().TransformPoint(colModel->m_boundBox.GetSize());
 
                                 bool bObjectDamage = false;
                                 if (GetPosition().z > boundBoxPos.z) {
@@ -4471,7 +4471,7 @@ bool CPhysical::ProcessCollisionSectorList(int32 sectorX, int32 sectorY)
                                 } else {
                                     CMatrix invertedMatrix;
                                     invertedMatrix = Invert(*m_matrix, invertedMatrix);
-                                    if ((invertedMatrix * boundBoxPos).z < 0.0f)
+                                    if ((invertedMatrix.TransformPoint(boundBoxPos)).z < 0.0f)
                                         bObjectDamage = true;
                                 }
                                 if (bObjectDamage)
@@ -4486,7 +4486,7 @@ bool CPhysical::ProcessCollisionSectorList(int32 sectorX, int32 sectorY)
                             if (entityObject->m_nColDamageEffect >= COL_DAMAGE_EFFECT_SMASH_COMPLETELY) {
 
                                 CColModel* colModel = mi->GetColModel();
-                                CVector boundBoxPos = (*m_matrix) * colModel->m_boundBox.GetSize();
+                                CVector boundBoxPos = (*m_matrix).TransformPoint(colModel->m_boundBox.GetSize());
 
                                 bool bObjectDamage = false;
                                 if (boundBoxPos.z < entity->GetPosition().z) {

--- a/source/game_sa/Entity/Physical.cpp
+++ b/source/game_sa/Entity/Physical.cpp
@@ -745,7 +745,7 @@ void CPhysical::ApplyTurnForce(CVector force, CVector point)
     {
         CVector vecCentreOfMassMultiplied{};
         if (!physicalFlags.bInfiniteMass)
-            vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce) {
             point.z = 0.0f;
@@ -772,7 +772,7 @@ void CPhysical::ApplyForce(CVector vecForce, CVector point, bool bUpdateTurnSpee
         if (physicalFlags.bInfiniteMass)
             fTurnMass += m_vecCentreOfMass.z * m_fMass * m_vecCentreOfMass.z * 0.5f;
         else
-            vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce) {
             point.z = 0.0f;
@@ -789,7 +789,7 @@ CVector CPhysical::GetSpeed(CVector point)
 {
     CVector vecCentreOfMassMultiplied{};
     if (!physicalFlags.bInfiniteMass)
-        vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+        vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
     CVector distance = point - vecCentreOfMassMultiplied;
     CVector vecTurnSpeed = m_vecTurnSpeed + m_vecFrictionTurnSpeed;
@@ -833,7 +833,7 @@ void CPhysical::ApplyTurnSpeed()
         GetUp() += vecCrossProduct;
         if (!physicalFlags.bInfiniteMass && !physicalFlags.bDisableMoveForce) {
             CVector vecNegativeCentreOfMass = m_vecCentreOfMass * -1.0f;
-            CVector vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), vecNegativeCentreOfMass);
+            CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), vecNegativeCentreOfMass);
             GetPosition() += CrossProduct(vecTurnSpeedTimeStep, vecCentreOfMassMultiplied);
         }
     }
@@ -845,7 +845,7 @@ void CPhysical::ApplyGravity()
     if (physicalFlags.bApplyGravity && !physicalFlags.bDisableMoveForce) {
         if (physicalFlags.bInfiniteMass) {
             float fMassTimeStep = CTimer::GetTimeStep() * m_fMass;
-            CVector point = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            CVector point = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
             CVector force (0.0f, 0.0f, fMassTimeStep * -0.008f);
             ApplyForce(force, point, true);
         }
@@ -897,7 +897,7 @@ void CPhysical::ApplyFrictionForce(CVector vecMoveForce, CVector point)
         if (physicalFlags.bInfiniteMass)
             fTurnMass += m_vecCentreOfMass.z * m_fMass * m_vecCentreOfMass.z * 0.5f;
         else
-            vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
         if (physicalFlags.bDisableMoveForce)
         {
@@ -1023,7 +1023,7 @@ bool CPhysical::ApplyCollision(CEntity* entity, CColPoint& colPoint, float& dama
         float fSpeedDotProduct = DotProduct(&vecMoveDirection, &vecSpeed);
         if (fSpeedDotProduct < 0.0f)
         {
-            CVector vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
             CVector vecDifference = vecDistanceToPoint - vecCentreOfMassMultiplied;
             CVector vecSpeedCrossProduct = CrossProduct(vecDifference, vecMoveDirection);
             float fSquaredMagnitude = vecMoveDirection.SquaredMagnitude();
@@ -1087,7 +1087,7 @@ bool CPhysical::ApplySoftCollision(CEntity* entity, CColPoint& colPoint, float& 
     }
 
     float fSpeedDotProduct = DotProduct(&vecSpeed, &vecMoveDirection);
-    CVector vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {
@@ -1205,7 +1205,7 @@ bool CPhysical::ApplySpringDampening(float fDampingForce, float fSpringForceDamp
             fDampingSpeed = -fCollisionPointSpeedDotProduct;
     }
 
-    CVector center = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+    CVector center = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
     CVector distance = collisionPoint - center;
     float fSpringForceDamping = GetMass(distance, direction) * fDampingSpeed;
     fSpringForceDampingLimit = fabs(fSpringForceDampingLimit) * DAMPING_LIMIT_OF_SPRING_FORCE;
@@ -1530,7 +1530,7 @@ bool CPhysical::ApplyCollisionAlt(CPhysical* entity, CColPoint& colPoint, float&
         return false;
     }
 
-    CVector vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
     if (physicalFlags.bInfiniteMass)
     {
         vecCentreOfMassMultiplied = CVector(0.0f, 0.0f, 0.0f);
@@ -1680,7 +1680,7 @@ bool CPhysical::ApplyCollisionAlt(CPhysical* entity, CColPoint& colPoint, float&
             outVecMoveSpeed += vecSpeed;
         }
 
-        vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+        vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
         float fTurnMass = m_fTurnMass;
         CVector vecDifference = vecDistanceToPointFromThis - vecCentreOfMassMultiplied; // todo: shadow var
         CVector vecCrossProduct = CrossProduct(vecDifference, vecMoveSpeed);            // todo: shadow var
@@ -1748,7 +1748,7 @@ bool CPhysical::ApplyFriction(float fFriction, CColPoint& colPoint)
 
     CVector vecMoveDirection = vecSpeedDifference / fMoveSpeedMagnitude;
 
-    CVector vecCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+    CVector vecCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
     CVector vecDifference = vecDistanceToPointFromThis - vecCentreOfMassMultiplied;
     CVector vecSpeedCrossProduct = CrossProduct(vecDifference, vecMoveDirection);
     float squaredMagnitude = vecSpeedCrossProduct.SquaredMagnitude();
@@ -1846,7 +1846,7 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
         float fEntitySpeedMagnitude = vecEntitySpeedDifference.Magnitude();
 
         CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
-        CVector vecEntityCentreOfMassMultiplied = Multiply3x3(entity->GetMatrix(), entity->m_vecCentreOfMass);
+        CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
         CVector vecEntityDifference = vecDistanceToPoint - vecEntityCentreOfMassMultiplied;
         CVector vecEntitySpeedCrossProduct = CrossProduct(vecEntityDifference, vecMoveDirection);
         float squaredMagnitude = vecEntitySpeedCrossProduct.SquaredMagnitude();
@@ -1902,14 +1902,14 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
 
         CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
 
-        CVector vecThisCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+        CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
         CVector vecThisDifference = vecDistanceToPointFromThis - vecThisCentreOfMassMultiplied;
         CVector vecThisSpeedCrossProduct = CrossProduct(vecThisDifference, vecMoveDirection);
         float squaredMagnitude = vecThisSpeedCrossProduct.SquaredMagnitude();
         float fThisCollisionMass = 1.0f / (squaredMagnitude / m_fTurnMass + 1.0f / m_fMass);
 
-        CVector vecEntityCentreOfMassMultiplied = Multiply3x3(entity->GetMatrix(), entity->m_vecCentreOfMass);
+        CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
 
         CVector vecEntityDifference = vecDistanceToPoint - vecEntityCentreOfMassMultiplied;
         CVector vecEntitySpeedCrossProduct = CrossProduct(vecEntityDifference, vecMoveDirection);
@@ -1959,7 +1959,7 @@ bool CPhysical::ApplyFriction(CPhysical* entity, float fFriction, CColPoint& col
 
     CVector vecMoveDirection = vecThisSpeedDifference * (1.0f / fThisSpeedMagnitude);
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
 
     CVector vecThisDifference = vecDistanceToPointFromThis - vecThisCentreOfMassMultiplied;
     CVector vecThisSpeedCrossProduct = CrossProduct(vecThisDifference, vecMoveDirection);
@@ -2344,7 +2344,7 @@ void CPhysical::PositionAttachedEntity()
         CVector vecMoveSpeedDifference = vecMoveSpeed - m_vecMoveSpeed;
         m_vecMoveSpeed = vecMoveSpeed;
         CVector vecForce = vecMoveSpeedDifference * m_fMass * -1.0f;
-        CVector vecCenterOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+        CVector vecCenterOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
         ApplyForce(vecForce, vecCenterOfMassMultiplied, true);
         if (m_pAttachedTo->IsVehicle() || m_pAttachedTo->IsObject()) {
             if (m_pAttachedTo->m_bUsesCollision && !m_pAttachedTo->physicalFlags.bDisableCollisionForce) {
@@ -2690,8 +2690,8 @@ bool CPhysical::ApplyCollision(CEntity* theEntity, CColPoint& colPoint, float& t
         bThisPedIsStandingOnEntity = false;
     }
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
-    CVector vecEntityCentreOfMassMultiplied = Multiply3x3(entity->GetMatrix(), entity->m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(entity->GetMatrix(), entity->m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {
@@ -3426,8 +3426,8 @@ bool CPhysical::ApplySoftCollision(CPhysical* physical, CColPoint& colPoint, flo
         bThisPedIsStandingOnEntity = false;
     }
 
-    CVector vecThisCentreOfMassMultiplied = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
-    CVector vecEntityCentreOfMassMultiplied = Multiply3x3(physical->GetMatrix(), physical->m_vecCentreOfMass);
+    CVector vecThisCentreOfMassMultiplied = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+    CVector vecEntityCentreOfMassMultiplied = Multiply3x3_MV(physical->GetMatrix(), physical->m_vecCentreOfMass);
 
     if (physicalFlags.bInfiniteMass)
     {

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -1533,8 +1533,8 @@ void CAutomobile::DoHoverSuspensionRatios()
         auto colData = GetColModel()->m_pColData;
         for (int32 i = 0; i < 4; i++)  {
             CColLine& line = colData->m_pLines[i];
-            CVector start = *m_matrix * line.m_vecStart;
-            CVector end = *m_matrix * line.m_vecEnd;
+            CVector start = m_matrix->TransformPoint(line.m_vecStart);
+            CVector end = m_matrix->TransformPoint(line.m_vecEnd);
             float colPointZ = MAP_Z_LOW_LIMIT;
             if (m_fWheelsSuspensionCompression[i] < 1.0f) {
                 colPointZ = m_wheelColPoint[i].m_vecPoint.z;
@@ -3834,7 +3834,7 @@ bool CAutomobile::UpdateMovingCollision(float angle) {
                 for (int32 i = 0; i < 3; i++) {
                     CVector vertexPos = UncompressVector(colData->m_pVertices[colTriangle.m_vertIndices[i]]);
                     CVector distance  = vertexPos - componentPos;
-                    vertexPos = (rotMatrix * distance) + componentPos;
+                    vertexPos = rotMatrix.TransformPoint(distance) + componentPos;
                     specialColData->m_pVertices[specialColTriangle.m_vertIndices[i]] = CompressVector(vertexPos);
                     if (maxZ < vertexPos.z)
                         maxZ = vertexPos.z;
@@ -3856,7 +3856,7 @@ bool CAutomobile::UpdateMovingCollision(float angle) {
             if (specialColSphere.m_Surface.m_nMaterial == SURFACE_CAR_MOVINGCOMPONENT) {
                 CColSphere& colSphere = colData->m_pSpheres[i];
                 CVector distance = colSphere.m_vecCenter - componentPos;
-                specialColSphere.m_vecCenter = (rotMatrix * distance) + componentPos;
+                specialColSphere.m_vecCenter = (rotMatrix.TransformPoint(distance)) + componentPos;
                 const float newMaxZ = specialColSphere.m_fRadius + specialColSphere.m_vecCenter.z;
                 const float newMinZ = specialColSphere.m_vecCenter.z - specialColSphere.m_fRadius;
                 if (maxZ < newMaxZ)
@@ -4305,7 +4305,7 @@ void CAutomobile::DoNitroEffect(float power) {
     bool secondExhaustSubmergedInWater = false;
     float level = 0.0f;
     if (physicalFlags.bTouchingWater) {
-        CVector point = *m_matrix * exhaustPosition;
+        CVector point = m_matrix->TransformPoint(exhaustPosition);
         if (CWaterLevel::GetWaterLevel(point.x, point.y, point.z, level, true, nullptr)) {
             if (level >= point.z)
                 firstExhaustSubmergedInWater = true;

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -4316,7 +4316,7 @@ void CAutomobile::DoNitroEffect(float power) {
         secondExhaustPosition = exhaustPosition;
         secondExhaustPosition.x *= -1.0f;
         if (!physicalFlags.bTouchingWater) {
-            CVector point = *m_matrix * secondExhaustPosition;
+            CVector point = m_matrix->TransformPoint(secondExhaustPosition);
             if (CWaterLevel::GetWaterLevel(point, level, true)) {
                 if (level >= point.z)
                     secondExhaustSubmergedInWater = true;
@@ -5415,7 +5415,7 @@ void CAutomobile::ProcessHarvester()
     if (!m_harvesterParticleCounter)
         return;
 
-    CVector pos = *m_matrix * CVector(-1.2f, -3.8f, 1.5f);
+    CVector pos = m_matrix->TransformPoint(CVector(-1.2f, -3.8f, 1.5f));
     CVector velocity = GetForward() * -0.1f;
     velocity.x += CGeneral::GetRandomNumberInRange(0.05f, -0.05f);
     velocity.y += CGeneral::GetRandomNumberInRange(0.05f, -0.05f);
@@ -5654,7 +5654,7 @@ void CAutomobile::TankControl()
         if (CPad::GetPad()->CarGunJustDown()) {
             if (CTimer::GetTimeInMS() > m_nGunFiringTime + TIGER_GUNFIRE_RATE) {
                 CWeapon minigun(WEAPON_MINIGUN, 5000);
-                CVector point = *m_matrix * TIGER_GUN_POS + CTimer::GetTimeStep() * m_vecMoveSpeed;
+                CVector point = m_matrix->TransformPoint(TIGER_GUN_POS + CTimer::GetTimeStep() * m_vecMoveSpeed);
                 minigun.FireInstantHit(this, &point, &point, nullptr, nullptr, nullptr, false, true);
                 CVector2D direction(0.0f, 0.1f);
                 minigun.AddGunshell(this, point, direction, 0.025f);
@@ -5765,7 +5765,7 @@ void CAutomobile::TankControl()
                 // BUG?: This statement is not assigned to any variable.
                 // It should be `newTurretPosition =  *m_matrix * doomOffset`
                 // Izzotop: Fixed, equal to OG code; untested -> remove ^ after tests
-                newTurretPosition = *m_matrix * doomOffset;
+                newTurretPosition = m_matrix->TransformPoint(doomOffset);
             }
 
             CVector distance = newTurretPosition - GetPosition();
@@ -6310,7 +6310,7 @@ bool CAutomobile::RcbanditCheck1CarWheels(CPtrList& ptrList)
                 wheelMatrix = Invert(*m_matrix, wheelMatrix);
 
                 CColSphere sphere;
-                sphere.m_vecCenter = wheelMatrix * (*vehicle->m_matrix * wheelPos);
+                sphere.m_vecCenter = wheelMatrix.TransformPoint(vehicle->m_matrix->TransformPoint(wheelPos));
                 sphere.m_fRadius = modelInfo->m_fWheelSizeFront * 0.25f;
                 if (CCollision::TestSphereBox(sphere, colModel->m_boundBox))
                     return true;
@@ -6429,9 +6429,8 @@ void CAutomobile::FireTruckControl(CFire* fire) {
     if (m_aCarNodes[CAR_MISC_A]) {
         RwMatrix* carNodeMiscMatrix = RwFrameGetLTM(m_aCarNodes[CAR_MISC_A]);
         newTurretPosition = *RwMatrixGetPos(carNodeMiscMatrix);
-    }
-    else {
-        newTurretPosition = *m_matrix * CVector(0.0f, 1.5f, 1.8f);
+    } else {
+        newTurretPosition = m_matrix->TransformPoint(CVector(0.0f, 1.5f, 1.8f));
     }
 
     CVector point{

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -5680,7 +5680,7 @@ void CAutomobile::TankControl()
         m_fDoomVerticalRotation   -= ((float)pad->GetCarGunLeftRight() * CTimer::GetTimeStep() * 0.015f) / 128.0f;
         m_fDoomHorizontalRotation += ((float)pad->GetCarGunUpDown() * CTimer::GetTimeStep() * 0.005f) / 128.0f;
     } else {
-        CVector frontDot = Multiply3x3_VM(activeCam.m_vecFront, GetMatrix());
+        CVector frontDot = GetMatrix().InverseTransformVector(activeCam.m_vecFront);
         float doomVerticalRotation   = std::atan2(-frontDot.x, frontDot.y);
         float doomHorizontalRotation = std::atan2(frontDot.z, frontDot.Magnitude2D()) + DegreesToRadians(15);
 
@@ -6382,7 +6382,7 @@ void CAutomobile::FireTruckControl(CFire* fire) {
             m_fDoomHorizontalRotation += ((float)pad->GetCarGunUpDown()    * CTimer::GetTimeStepInSeconds()) / 128.0f;
         }
         else {
-            CVector frontDot = Multiply3x3_VM(activeCam.m_vecFront, GetMatrix());
+            CVector frontDot = GetMatrix().InverseTransformVector(activeCam.m_vecFront);
             float doomVerticalRotation   = std::atan2(-frontDot.x, frontDot.y);
             float doomHorizontalRotation = std::atan2(+frontDot.z, frontDot.Magnitude2D());
 

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -696,10 +696,10 @@ void CAutomobile::ProcessControl()
                     CVector& point = contactPoints[i];
                     point = colDisk.m_vecCenter;
                     point.z -= colDisk.m_fRadius;
-                    point = Multiply3x3_MV(GetMatrix(), contactPoints[i]);
+                    point = GetMatrix().TransformVector(contactPoints[i]);
                 }
                 else {
-                    contactPoints[i] = Multiply3x3_MV(GetMatrix(), colLine.m_vecEnd);
+                    contactPoints[i] = GetMatrix().TransformVector(colLine.m_vecEnd);
                 }
             }
             else {
@@ -1037,7 +1037,7 @@ void CAutomobile::ProcessControl()
             speed -= turnSpeedForward;
 
             CVector force = speed * GetUp() * -1.0f * m_fTurnMass;
-            CVector point = GetRight() + Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+            CVector point = GetRight() + GetMatrix().TransformVector(m_vecCentreOfMass);
             ApplyTurnForce(force, point);
         }
     }
@@ -1175,8 +1175,8 @@ CVector CAutomobile::AddMovingCollisionSpeed(CVector& point) {
         colPivot = RwFrameGetMatrix(carNodeMisc)->pos;
     }
     CVector rotation(float(angleDiff) / CTimer::GetTimeStep() * colAngleMult, 0.0f, 0.0f);
-    CVector pos = Multiply3x3_MV(GetMatrix(), rotation);
-    CVector pivotPos = Multiply3x3_MV(GetMatrix(), colPivot);
+    CVector pos = GetMatrix().TransformVector(rotation);
+    CVector pivotPos = GetMatrix().TransformVector(colPivot);
     CVector distance = point - pivotPos;
     return CrossProduct(pos, distance);
 }
@@ -1692,7 +1692,7 @@ void CAutomobile::ProcessSuspension() {
             CColLine& colLine   = colData->m_pLines[wheelLineIndices[i]];
             contactPoints[i]    = colLine.m_vecStart;
             contactPoints[i].z -= m_aSuspensionLineLength[i] * springLength[i];
-            contactPoints[i]    = Multiply3x3_MV(GetMatrix(), contactPoints[i]);
+            contactPoints[i]    = GetMatrix().TransformVector(contactPoints[i]);
         }
     }
 
@@ -5499,7 +5499,7 @@ void CAutomobile::ProcessSwingingDoor(eCarNodes nodeIdx, eDoors doorIdx)
             this,
             m_moveForce,
             m_turnForce,
-            Multiply3x3_MV(*m_matrix, frameMatrix.GetPosition())
+            m_matrix->TransformVector(frameMatrix.GetPosition())
         )) {
             m_damageManager.SetDoorOpen(doorIdx);
         }
@@ -5525,7 +5525,7 @@ void CAutomobile::ProcessSwingingDoor(eCarNodes nodeIdx, eDoors doorIdx)
         this,
         m_moveForce,
         m_turnForce,
-        Multiply3x3_MV(*m_matrix, frameMatrix.GetPosition())
+        m_matrix->TransformVector(frameMatrix.GetPosition())
     )) {
         m_damageManager.SetDoorClosed(doorIdx);
         m_vehicleAudio.AddAudioEvent((eAudioEvents)((int32)AE_CAR_BONNET_CLOSE + (int32)doorIdx), 0.f);
@@ -5737,7 +5737,7 @@ void CAutomobile::TankControl()
             point.x = std::sin(-m_fDoomVerticalRotation);
             point.y = std::cos(m_fDoomVerticalRotation);
             point.z = std::sin(m_fDoomHorizontalRotation);
-            point = Multiply3x3_MV(GetMatrix(), point);
+            point = GetMatrix().TransformVector(point);
 
             CVector newTurretPosition;
             if (m_aCarNodes[CAR_MISC_C]) { // 0x6AED5D
@@ -6439,7 +6439,7 @@ void CAutomobile::FireTruckControl(CFire* fire) {
         std::cos(m_fDoomVerticalRotation)   * std::cos(m_fDoomHorizontalRotation),
         std::sin(m_fDoomHorizontalRotation),
     };
-    point = Multiply3x3_MV(GetMatrix(), point); // 0x72A062
+    point = GetMatrix().TransformVector(point); // 0x72A062
 
     if (m_aCarNodes[CAR_MISC_A]) {
         if (ModelIndices::IsSwatVan(m_nModelIndex))

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -696,10 +696,10 @@ void CAutomobile::ProcessControl()
                     CVector& point = contactPoints[i];
                     point = colDisk.m_vecCenter;
                     point.z -= colDisk.m_fRadius;
-                    point = Multiply3x3(GetMatrix(), contactPoints[i]);
+                    point = Multiply3x3_MV(GetMatrix(), contactPoints[i]);
                 }
                 else {
-                    contactPoints[i] = Multiply3x3(GetMatrix(), colLine.m_vecEnd);
+                    contactPoints[i] = Multiply3x3_MV(GetMatrix(), colLine.m_vecEnd);
                 }
             }
             else {
@@ -1037,7 +1037,7 @@ void CAutomobile::ProcessControl()
             speed -= turnSpeedForward;
 
             CVector force = speed * GetUp() * -1.0f * m_fTurnMass;
-            CVector point = GetRight() + Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+            CVector point = GetRight() + Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
             ApplyTurnForce(force, point);
         }
     }
@@ -1175,8 +1175,8 @@ CVector CAutomobile::AddMovingCollisionSpeed(CVector& point) {
         colPivot = RwFrameGetMatrix(carNodeMisc)->pos;
     }
     CVector rotation(float(angleDiff) / CTimer::GetTimeStep() * colAngleMult, 0.0f, 0.0f);
-    CVector pos = Multiply3x3(GetMatrix(), rotation);
-    CVector pivotPos = Multiply3x3(GetMatrix(), colPivot);
+    CVector pos = Multiply3x3_MV(GetMatrix(), rotation);
+    CVector pivotPos = Multiply3x3_MV(GetMatrix(), colPivot);
     CVector distance = point - pivotPos;
     return CrossProduct(pos, distance);
 }
@@ -1692,7 +1692,7 @@ void CAutomobile::ProcessSuspension() {
             CColLine& colLine   = colData->m_pLines[wheelLineIndices[i]];
             contactPoints[i]    = colLine.m_vecStart;
             contactPoints[i].z -= m_aSuspensionLineLength[i] * springLength[i];
-            contactPoints[i]    = Multiply3x3(GetMatrix(), contactPoints[i]);
+            contactPoints[i]    = Multiply3x3_MV(GetMatrix(), contactPoints[i]);
         }
     }
 
@@ -5499,7 +5499,7 @@ void CAutomobile::ProcessSwingingDoor(eCarNodes nodeIdx, eDoors doorIdx)
             this,
             m_moveForce,
             m_turnForce,
-            Multiply3x3(*m_matrix, frameMatrix.GetPosition())
+            Multiply3x3_MV(*m_matrix, frameMatrix.GetPosition())
         )) {
             m_damageManager.SetDoorOpen(doorIdx);
         }
@@ -5525,7 +5525,7 @@ void CAutomobile::ProcessSwingingDoor(eCarNodes nodeIdx, eDoors doorIdx)
         this,
         m_moveForce,
         m_turnForce,
-        Multiply3x3(*m_matrix, frameMatrix.GetPosition())
+        Multiply3x3_MV(*m_matrix, frameMatrix.GetPosition())
     )) {
         m_damageManager.SetDoorClosed(doorIdx);
         m_vehicleAudio.AddAudioEvent((eAudioEvents)((int32)AE_CAR_BONNET_CLOSE + (int32)doorIdx), 0.f);
@@ -5680,7 +5680,7 @@ void CAutomobile::TankControl()
         m_fDoomVerticalRotation   -= ((float)pad->GetCarGunLeftRight() * CTimer::GetTimeStep() * 0.015f) / 128.0f;
         m_fDoomHorizontalRotation += ((float)pad->GetCarGunUpDown() * CTimer::GetTimeStep() * 0.005f) / 128.0f;
     } else {
-        CVector frontDot = Multiply3x3(activeCam.m_vecFront, GetMatrix());
+        CVector frontDot = Multiply3x3_VM(activeCam.m_vecFront, GetMatrix());
         float doomVerticalRotation   = std::atan2(-frontDot.x, frontDot.y);
         float doomHorizontalRotation = std::atan2(frontDot.z, frontDot.Magnitude2D()) + DegreesToRadians(15);
 
@@ -5737,7 +5737,7 @@ void CAutomobile::TankControl()
             point.x = std::sin(-m_fDoomVerticalRotation);
             point.y = std::cos(m_fDoomVerticalRotation);
             point.z = std::sin(m_fDoomHorizontalRotation);
-            point = Multiply3x3(GetMatrix(), point);
+            point = Multiply3x3_MV(GetMatrix(), point);
 
             CVector newTurretPosition;
             if (m_aCarNodes[CAR_MISC_C]) { // 0x6AED5D
@@ -6382,7 +6382,7 @@ void CAutomobile::FireTruckControl(CFire* fire) {
             m_fDoomHorizontalRotation += ((float)pad->GetCarGunUpDown()    * CTimer::GetTimeStepInSeconds()) / 128.0f;
         }
         else {
-            CVector frontDot = Multiply3x3(activeCam.m_vecFront, GetMatrix());
+            CVector frontDot = Multiply3x3_VM(activeCam.m_vecFront, GetMatrix());
             float doomVerticalRotation   = std::atan2(-frontDot.x, frontDot.y);
             float doomHorizontalRotation = std::atan2(+frontDot.z, frontDot.Magnitude2D());
 
@@ -6439,7 +6439,7 @@ void CAutomobile::FireTruckControl(CFire* fire) {
         std::cos(m_fDoomVerticalRotation)   * std::cos(m_fDoomHorizontalRotation),
         std::sin(m_fDoomHorizontalRotation),
     };
-    point = Multiply3x3(GetMatrix(), point); // 0x72A062
+    point = Multiply3x3_MV(GetMatrix(), point); // 0x72A062
 
     if (m_aCarNodes[CAR_MISC_A]) {
         if (ModelIndices::IsSwatVan(m_nModelIndex))

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -687,7 +687,7 @@ void CBoat::PreRender_Reversed() {
             auto tempMat = CMatrix();
             tempMat.Attach(RwFrameGetMatrix(pFlap), false);
             CVector& posCopy = tempMat.GetPosition();
-            auto vecTransformed = Multiply3x3(GetMatrix(), posCopy);
+            auto vecTransformed = Multiply3x3_MV(GetMatrix(), posCopy);
 
             m_boatFlap.Process(this, m_vecBoatMoveForce, m_vecBoatTurnForce, vecTransformed);
             CVector vecAxis;

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -687,7 +687,7 @@ void CBoat::PreRender_Reversed() {
             auto tempMat = CMatrix();
             tempMat.Attach(RwFrameGetMatrix(pFlap), false);
             CVector& posCopy = tempMat.GetPosition();
-            auto vecTransformed = Multiply3x3_MV(GetMatrix(), posCopy);
+            auto vecTransformed = GetMatrix().TransformVector(posCopy);
 
             m_boatFlap.Process(this, m_vecBoatMoveForce, m_vecBoatTurnForce, vecTransformed);
             CVector vecAxis;

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -215,7 +215,7 @@ void CQuadBike::ProcessControl() {
         return;
     }
 
-    const auto turnSpeed_Mult_Matrix = Multiply3x3_VM(m_vecTurnSpeed, *m_matrix);
+    const auto turnSpeed_Mult_Matrix = m_matrix->InverseTransformVector(m_vecTurnSpeed);
     float v2 = vecQuadResistance.y, v5 = vecQuadResistance.x;
     if (AreFrontWheelsNotTouchingGround()) {
         if (!AreRearWheelsNotTouchingGround() && m_matrix->GetForward().z > 0.0f) {
@@ -231,18 +231,18 @@ void CQuadBike::ProcessControl() {
         }
     }
 
-    const CVector worldSpaceSpeed = Multiply3x3_VM(m_vecTurnSpeed, *m_matrix);
+    const CVector velocityOS = m_matrix->InverseTransformVector(m_vecTurnSpeed);
     CVector unk{ // In the original code `x` is calculated once then immediately overwritten by the below line
         std::pow(vecQuadResistance.x, CTimer::GetTimeStep()),
-        vecQuadResistance.y / (worldSpaceSpeed.y * worldSpaceSpeed.y + 1.0f),
+        vecQuadResistance.y / (velocityOS.y * velocityOS.y + 1.0f),
         1.0f
     };
-    const auto worldCentreOfMass = Multiply3x3_VM(m_vecCentreOfMass, *m_matrix);
+    const auto worldCentreOfMass = m_matrix->InverseTransformVector(m_vecCentreOfMass);
 
-    const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * worldSpaceSpeed.y - worldSpaceSpeed.y;
+    const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * velocityOS.y - velocityOS.y;
     ApplyTurnForce(m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass, m_matrix->GetRight() + worldCentreOfMass);
 
-    const float v19 = worldSpaceSpeed.x * unk.x - worldSpaceSpeed.x;
+    const float v19 = velocityOS.x * unk.x - velocityOS.x;
     ApplyTurnForce(m_matrix->GetUp() * v19 * m_fTurnMass, m_matrix->GetForward() + worldCentreOfMass);
 
     CAutomobile::ProcessControl();

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -237,13 +237,13 @@ void CQuadBike::ProcessControl() {
         vecQuadResistance.y / (velocityOS.y * velocityOS.y + 1.0f),
         1.0f
     };
-    const auto worldCentreOfMass = m_matrix->InverseTransformVector(m_vecCentreOfMass);
+    const auto centreOfMassOS = m_matrix->InverseTransformVector(m_vecCentreOfMass);
 
     const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * velocityOS.y - velocityOS.y;
-    ApplyTurnForce(m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass, m_matrix->GetRight() + worldCentreOfMass);
+    ApplyTurnForce(m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass, m_matrix->GetRight() + centreOfMassOS);
 
     const float v19 = velocityOS.x * unk.x - velocityOS.x;
-    ApplyTurnForce(m_matrix->GetUp() * v19 * m_fTurnMass, m_matrix->GetForward() + worldCentreOfMass);
+    ApplyTurnForce(m_matrix->GetUp() * v19 * m_fTurnMass, m_matrix->GetForward() + centreOfMassOS);
 
     CAutomobile::ProcessControl();
 }

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -215,7 +215,7 @@ void CQuadBike::ProcessControl() {
         return;
     }
 
-    const auto turnSpeed_Mult_Matrix = Multiply3x3(m_vecTurnSpeed, *m_matrix);
+    const auto turnSpeed_Mult_Matrix = Multiply3x3_VM(m_vecTurnSpeed, *m_matrix);
     float v2 = vecQuadResistance.y, v5 = vecQuadResistance.x;
     if (AreFrontWheelsNotTouchingGround()) {
         if (!AreRearWheelsNotTouchingGround() && m_matrix->GetForward().z > 0.0f) {
@@ -231,13 +231,13 @@ void CQuadBike::ProcessControl() {
         }
     }
 
-    const CVector worldSpaceSpeed = Multiply3x3(m_vecTurnSpeed, *m_matrix);
+    const CVector worldSpaceSpeed = Multiply3x3_VM(m_vecTurnSpeed, *m_matrix);
     CVector unk{ // In the original code `x` is calculated once then immediately overwritten by the below line
         std::pow(vecQuadResistance.x, CTimer::GetTimeStep()),
         vecQuadResistance.y / (worldSpaceSpeed.y * worldSpaceSpeed.y + 1.0f),
         1.0f
     };
-    const auto worldCentreOfMass = Multiply3x3(m_vecCentreOfMass, *m_matrix);
+    const auto worldCentreOfMass = Multiply3x3_VM(m_vecCentreOfMass, *m_matrix);
 
     const float v9 = std::pow(unk.y, CTimer::GetTimeStep()) * worldSpaceSpeed.y - worldSpaceSpeed.y;
     ApplyTurnForce(m_matrix->GetUp() * -1.0f * v9 * m_fTurnMass, m_matrix->GetRight() + worldCentreOfMass);

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -1975,11 +1975,11 @@ void CVehicle::ApplyBoatWaterResistance(tBoatHandlingData* boatHandling, float f
     float fUsedTimeStep = CTimer::GetTimeStep() * 0.5F;
     auto vecSpeedMult = Pow(boatHandling->m_vecMoveRes * fSpeedMult, fUsedTimeStep);
 
-    CVector vecMoveSpeedMatrixDotProduct = Multiply3x3(m_vecMoveSpeed, GetMatrix());
+    CVector vecMoveSpeedMatrixDotProduct = Multiply3x3_VM(m_vecMoveSpeed, GetMatrix());
     m_vecMoveSpeed = vecMoveSpeedMatrixDotProduct * vecSpeedMult;
 
     auto fMassMult = (vecSpeedMult.y - 1.0F) * m_vecMoveSpeed.y * m_fMass;
-    CVector vecTransformedMoveSpeed = Multiply3x3(GetMatrix(), m_vecMoveSpeed);
+    CVector vecTransformedMoveSpeed = Multiply3x3_MV(GetMatrix(), m_vecMoveSpeed);
     m_vecMoveSpeed = vecTransformedMoveSpeed;
 
     auto vecDown = GetUp() * -1.0F;
@@ -3454,7 +3454,7 @@ bool CVehicle::BladeColSectorList(CPtrList& ptrList, CColModel& colModel, CMatri
     };
 
     const auto [rotorUp, rotorSizeMS] = GetRotorDirUpAndThickness();
-    const auto rotorSize              = Multiply3x3(matrix, rotorSizeMS);
+    const auto rotorSize              = Multiply3x3_MV(matrix, rotorSizeMS);
     const auto colModelCenter         = MultiplyMatrixWithVector(matrix, colModel.GetBoundCenter());
     const auto& thisPosn              = GetPosition();
 
@@ -3761,7 +3761,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
             const auto& vecBoundingMin = CEntity::GetColModel()->m_boundBox.m_vecMin;
             CVector vecThrustPoint(0.0F, vecBoundingMin.y * boatHandling->m_fThrustY, vecBoundingMin.z * boatHandling->m_fThrustZ);
-            auto vecTransformedThrustPoint = Multiply3x3(GetMatrix(), vecThrustPoint);
+            auto vecTransformedThrustPoint = Multiply3x3_MV(GetMatrix(), vecThrustPoint);
 
             auto vecWorldThrustPos = GetPosition() + vecTransformedThrustPoint;
             float fWaterLevel;
@@ -3788,7 +3788,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
                     auto fSteerAngle = std::fabs(m_fSteerAngle);
                     CVector vecSteer(-fSteerAngleSin, fSteerAngleCos, -fSteerAngle);
-                    CVector vecSteerMoveForce = Multiply3x3(GetMatrix(), vecSteer);
+                    CVector vecSteerMoveForce = Multiply3x3_MV(GetMatrix(), vecSteer);
                     vecSteerMoveForce *= fThrustDepth * m_fGasPedal * 40.0F * m_pHandlingData->m_transmissionData.m_fEngineAcceleration * m_fMass;
 
                     if (vecSteerMoveForce.z > 0.2F)
@@ -3841,7 +3841,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
                     CVector vecTractionLoss(-fSteerAngleSin, 0.0F, 0.0F);
                     vecTractionLoss *= fTractionLoss;
-                    CVector vecTractionLossTransformed = Multiply3x3(GetMatrix(), vecTractionLoss);
+                    CVector vecTractionLossTransformed = Multiply3x3_MV(GetMatrix(), vecTractionLoss);
                     vecTractionLossTransformed *= fThrustDepth * CTimer::GetTimeStep();
 
                     CPhysical::ApplyMoveForce(vecTractionLossTransformed);
@@ -3889,7 +3889,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
     // 0x6DCD63
     if ((m_nModelIndex != MODEL_SKIMMER || m_f2ndSteerAngle == 0.0F) && !bCollidedWithWorld) {
         auto vecTurnRes = Pow(boatHandling->m_vecTurnRes, CTimer::GetTimeStep());
-        m_vecTurnSpeed = Multiply3x3(m_vecTurnSpeed, GetMatrix());
+        m_vecTurnSpeed = Multiply3x3_VM(m_vecTurnSpeed, GetMatrix());
         m_vecTurnSpeed.y *= vecTurnRes.y;
         m_vecTurnSpeed.z *= vecTurnRes.z;
 
@@ -3897,8 +3897,8 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
         fMult *= m_fTurnMass;
         auto vecTurnForce = GetUp() * fMult;
 
-        m_vecTurnSpeed = Multiply3x3(GetMatrix(), m_vecTurnSpeed);
-        auto vecCentreOfMass = Multiply3x3(GetMatrix(), m_vecCentreOfMass);
+        m_vecTurnSpeed = Multiply3x3_MV(GetMatrix(), m_vecTurnSpeed);
+        auto vecCentreOfMass = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
         auto vecTurnPoint = GetForward() + vecCentreOfMass;
         CPhysical::ApplyTurnForce(vecTurnForce, vecTurnPoint);
     }
@@ -4267,7 +4267,7 @@ void CVehicle::DoHeadLightBeam(eVehicleDummy dummyId, CMatrix& matrix, bool arg2
     if (dummyId == DUMMY_LIGHT_REAR_MAIN && pointModelSpace.IsZero())
         return;
 
-    CVector point = matrix.GetPosition() + Multiply3x3(matrix, pointModelSpace);
+    CVector point = matrix.GetPosition() + Multiply3x3_MV(matrix, pointModelSpace);
     if (!arg2) {
         point -= 2 * pointModelSpace.x * matrix.GetRight();
     }

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -2584,7 +2584,7 @@ CVector CVehicle::GetDriverSeatDummyPositionOS() const {
 }
 
 CVector CVehicle::GetDriverSeatDummyPositionWS() {
-    return GetMatrix().TransformPoint(GetDriverSeatDummyPositionOS())
+    return GetMatrix().TransformPoint(GetDriverSeatDummyPositionOS());
 }
 
 CVehicleAnimGroup& CVehicle::GetAnimGroup() const {
@@ -4112,7 +4112,7 @@ void CVehicle::AddExhaustParticles() {
         vecParticleVelocity = randomFactor * GetForward();
     }
 
-    firstExhaustPos = entityMatrix * firstExhaustPos;
+    firstExhaustPos = entityMatrix.TransformPoint(firstExhaustPos);
     bool bFirstExhaustSubmergedInWater = false;
     bool bSecondExhaustSubmergedInWater = false;
     float pLevel = 0.0f;
@@ -4122,7 +4122,7 @@ void CVehicle::AddExhaustParticles() {
     }
 
     if (bHasDoubleExhaust) {
-        secondExhaustPos = entityMatrix * secondExhaustPos;
+        secondExhaustPos = entityMatrix.TransformPoint(secondExhaustPos);
         if (physicalFlags.bTouchingWater && CWaterLevel::GetWaterLevel(secondExhaustPos, pLevel, true) &&
             pLevel >= secondExhaustPos.z) {
             bSecondExhaustSubmergedInWater = true;

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -1979,7 +1979,7 @@ void CVehicle::ApplyBoatWaterResistance(tBoatHandlingData* boatHandling, float f
     m_vecMoveSpeed = vecMoveSpeedMatrixDotProduct * vecSpeedMult;
 
     auto fMassMult = (vecSpeedMult.y - 1.0F) * m_vecMoveSpeed.y * m_fMass;
-    CVector vecTransformedMoveSpeed = Multiply3x3_MV(GetMatrix(), m_vecMoveSpeed);
+    CVector vecTransformedMoveSpeed = GetMatrix().TransformVector(m_vecMoveSpeed);
     m_vecMoveSpeed = vecTransformedMoveSpeed;
 
     auto vecDown = GetUp() * -1.0F;
@@ -3454,7 +3454,7 @@ bool CVehicle::BladeColSectorList(CPtrList& ptrList, CColModel& colModel, CMatri
     };
 
     const auto [rotorUp, rotorSizeMS] = GetRotorDirUpAndThickness();
-    const auto rotorSize              = Multiply3x3_MV(matrix, rotorSizeMS);
+    const auto rotorSize              = matrix.TransformVector(rotorSizeMS);
     const auto colModelCenter         = MultiplyMatrixWithVector(matrix, colModel.GetBoundCenter());
     const auto& thisPosn              = GetPosition();
 
@@ -3761,7 +3761,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
             const auto& vecBoundingMin = CEntity::GetColModel()->m_boundBox.m_vecMin;
             CVector vecThrustPoint(0.0F, vecBoundingMin.y * boatHandling->m_fThrustY, vecBoundingMin.z * boatHandling->m_fThrustZ);
-            auto vecTransformedThrustPoint = Multiply3x3_MV(GetMatrix(), vecThrustPoint);
+            auto vecTransformedThrustPoint = GetMatrix().TransformVector(vecThrustPoint);
 
             auto vecWorldThrustPos = GetPosition() + vecTransformedThrustPoint;
             float fWaterLevel;
@@ -3788,7 +3788,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
                     auto fSteerAngle = std::fabs(m_fSteerAngle);
                     CVector vecSteer(-fSteerAngleSin, fSteerAngleCos, -fSteerAngle);
-                    CVector vecSteerMoveForce = Multiply3x3_MV(GetMatrix(), vecSteer);
+                    CVector vecSteerMoveForce = GetMatrix().TransformVector(vecSteer);
                     vecSteerMoveForce *= fThrustDepth * m_fGasPedal * 40.0F * m_pHandlingData->m_transmissionData.m_fEngineAcceleration * m_fMass;
 
                     if (vecSteerMoveForce.z > 0.2F)
@@ -3841,7 +3841,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
 
                     CVector vecTractionLoss(-fSteerAngleSin, 0.0F, 0.0F);
                     vecTractionLoss *= fTractionLoss;
-                    CVector vecTractionLossTransformed = Multiply3x3_MV(GetMatrix(), vecTractionLoss);
+                    CVector vecTractionLossTransformed = GetMatrix().TransformVector(vecTractionLoss);
                     vecTractionLossTransformed *= fThrustDepth * CTimer::GetTimeStep();
 
                     CPhysical::ApplyMoveForce(vecTractionLossTransformed);
@@ -3897,8 +3897,8 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
         fMult *= m_fTurnMass;
         auto vecTurnForce = GetUp() * fMult;
 
-        m_vecTurnSpeed = Multiply3x3_MV(GetMatrix(), m_vecTurnSpeed);
-        auto vecCentreOfMass = Multiply3x3_MV(GetMatrix(), m_vecCentreOfMass);
+        m_vecTurnSpeed = GetMatrix().TransformVector(m_vecTurnSpeed);
+        auto vecCentreOfMass = GetMatrix().TransformVector(m_vecCentreOfMass);
         auto vecTurnPoint = GetForward() + vecCentreOfMass;
         CPhysical::ApplyTurnForce(vecTurnForce, vecTurnPoint);
     }
@@ -4267,7 +4267,7 @@ void CVehicle::DoHeadLightBeam(eVehicleDummy dummyId, CMatrix& matrix, bool arg2
     if (dummyId == DUMMY_LIGHT_REAR_MAIN && pointModelSpace.IsZero())
         return;
 
-    CVector point = matrix.GetPosition() + Multiply3x3_MV(matrix, pointModelSpace);
+    CVector point = matrix.GetPosition() + matrix.TransformVector(pointModelSpace);
     if (!arg2) {
         point -= 2 * pointModelSpace.x * matrix.GetRight();
     }

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -581,14 +581,14 @@ void CVehicle::SpecialEntityPreCollisionStuff_Reversed(CPhysical* colPhysical, b
                     if (vecMax.x < 1.0F && vecMax.y < 1.0F && vecMax.z < 1.0F)
                     {
                         const auto vecSize = cm->GetBoundingBox().GetSize();
-                        const auto vecTransformed = *colPhysical->m_matrix * vecSize;
+                        const auto vecTransformed = colPhysical->m_matrix->TransformPoint(vecSize);
 
                         if (GetPosition().z > vecTransformed.z)
                             bCollidedEntityCollisionIgnored = true;
                         else
                         {
                             Invert(*m_matrix, tempMat);
-                            if ((tempMat * vecTransformed).z < 0.0F)
+                            if (tempMat.TransformPoint(vecTransformed).z < 0.0F) // `m_matrix->GetUp().Dot(vecTransformed)` should work too
                                 bCollidedEntityCollisionIgnored = true;
                         }
                     }
@@ -2017,7 +2017,7 @@ CVector CVehicle::GetDummyPositionObjSpace(eVehicleDummy dummy) const {
 CVector CVehicle::GetDummyPosition(eVehicleDummy dummy, bool bWorldSpace) {
     CVector pos = GetDummyPositionObjSpace(dummy);
     if (bWorldSpace)
-        pos = GetMatrix() * pos; // transform to world-space
+        pos = GetMatrix().TransformPoint(pos); // transform to world-space
     return pos;
 }
 
@@ -2584,7 +2584,7 @@ CVector CVehicle::GetDriverSeatDummyPositionOS() const {
 }
 
 CVector CVehicle::GetDriverSeatDummyPositionWS() {
-    return GetMatrix() * GetDriverSeatDummyPositionOS();
+    return GetMatrix().TransformPoint(GetDriverSeatDummyPositionOS())
 }
 
 CVehicleAnimGroup& CVehicle::GetAnimGroup() const {

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -1975,7 +1975,7 @@ void CVehicle::ApplyBoatWaterResistance(tBoatHandlingData* boatHandling, float f
     float fUsedTimeStep = CTimer::GetTimeStep() * 0.5F;
     auto vecSpeedMult = Pow(boatHandling->m_vecMoveRes * fSpeedMult, fUsedTimeStep);
 
-    CVector vecMoveSpeedMatrixDotProduct = Multiply3x3_VM(m_vecMoveSpeed, GetMatrix());
+    CVector vecMoveSpeedMatrixDotProduct = GetMatrix().InverseTransformVector(m_vecMoveSpeed);
     m_vecMoveSpeed = vecMoveSpeedMatrixDotProduct * vecSpeedMult;
 
     auto fMassMult = (vecSpeedMult.y - 1.0F) * m_vecMoveSpeed.y * m_fMass;
@@ -3889,7 +3889,7 @@ void CVehicle::ProcessBoatControl(tBoatHandlingData* boatHandling, float* fLastW
     // 0x6DCD63
     if ((m_nModelIndex != MODEL_SKIMMER || m_f2ndSteerAngle == 0.0F) && !bCollidedWithWorld) {
         auto vecTurnRes = Pow(boatHandling->m_vecTurnRes, CTimer::GetTimeStep());
-        m_vecTurnSpeed = Multiply3x3_VM(m_vecTurnSpeed, GetMatrix());
+        m_vecTurnSpeed = GetMatrix().InverseTransformVector(m_vecTurnSpeed);
         m_vecTurnSpeed.y *= vecTurnRes.y;
         m_vecTurnSpeed.z *= vecTurnRes.z;
 

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -1137,7 +1137,7 @@ bool CVehicle::GetTowHitchPos_Reversed(CVector& outPos, bool bCheckModelInfo, CV
 
     auto const fColFront = CModelInfo::GetModelInfo(m_nModelIndex)->GetColModel()->GetBoundingBox().m_vecMax.y;
     outPos.Set(0.0F, fColFront + 1.0F, 0.0F);
-    outPos = *m_matrix * outPos;
+    outPos = m_matrix->TransformPoint(outPos);
     return true;
 }
 
@@ -1151,7 +1151,7 @@ bool CVehicle::GetTowBarPos_Reversed(CVector& outPos, bool bCheckModelInfo, CVeh
 
     auto const fColRear = CModelInfo::GetModelInfo(m_nModelIndex)->GetColModel()->GetBoundingBox().m_vecMin.y;
     outPos.Set(0.0F, fColRear - 1.0F, 0.0F);
-    outPos = *m_matrix * outPos;
+    outPos = m_matrix->TransformPoint(outPos);
     return true;
 }
 
@@ -2596,27 +2596,27 @@ AssocGroupId CVehicle::GetAnimGroupId() const {
 }
 
 // 0x6D3CB0
-void CVehicle::ReleasePickedUpEntityWithWinch() {
+void CVehicle::ReleasePickedUpEntityWithWinch() const {
     return CRopes::GetRope(GetRopeID()).ReleasePickedUpObject();
 }
 
 // 0x6D3CD0
-void CVehicle::PickUpEntityWithWinch(CEntity* entity) {
+void CVehicle::PickUpEntityWithWinch(CEntity* entity) const {
     return CRopes::GetRope(GetRopeID()).PickUpObject(entity);
 }
 
 // 0x6D3CF0
-CEntity* CVehicle::QueryPickedUpEntityWithWinch() {
+CEntity* CVehicle::QueryPickedUpEntityWithWinch() const {
     return CRopes::GetRope(GetRopeID()).m_pRopeAttachObject;
 }
 
 // 0x6D3D10
-float CVehicle::GetRopeHeightForHeli() {
+float CVehicle::GetRopeHeightForHeli() const {
     return CRopes::GetRope(GetRopeID()).m_fSegmentLength;
 }
 
 // 0x6D3D30
-void CVehicle::SetRopeHeightForHeli(float height) {
+void CVehicle::SetRopeHeightForHeli(float height) const {
     CRopes::GetRope(GetRopeID()).m_fSegmentLength = height;
 }
 

--- a/source/game_sa/Entity/Vehicle/Vehicle.h
+++ b/source/game_sa/Entity/Vehicle/Vehicle.h
@@ -577,11 +577,11 @@ public:
     void InitWinch(int32 arg0);
     void UpdateWinch();
     void RemoveWinch();
-    void ReleasePickedUpEntityWithWinch();
-    void PickUpEntityWithWinch(CEntity* entity);
-    CEntity* QueryPickedUpEntityWithWinch();
-    float GetRopeHeightForHeli();
-    void SetRopeHeightForHeli(float height);
+    void ReleasePickedUpEntityWithWinch() const;
+    void PickUpEntityWithWinch(CEntity* entity) const;
+    CEntity* QueryPickedUpEntityWithWinch() const;
+    float GetRopeHeightForHeli() const;
+    void SetRopeHeightForHeli(float height) const;
     void RenderDriverAndPassengers();
     void PreRenderDriverAndPassengers();
     float GetPlaneGunsAutoAimAngle();

--- a/source/game_sa/Events/EventAttractor.cpp
+++ b/source/game_sa/Events/EventAttractor.cpp
@@ -85,7 +85,7 @@ bool CEventAttractor::AffectsPed_Reversed(CPed* ped)
                     return true;
                 if (!g_ikChainMan.IsLooking(ped)) {
                     uint32 time = CGeneral::GetRandomNumberInRange(2000, 4000);
-                    CVector point = m_entity->GetMatrix() * m_2dEffect->m_pos;
+                    CVector point = m_entity->GetMatrix().TransformPoint(m_2dEffect->m_pos);
                     g_ikChainMan.LookAt("CEventAttractor", ped, 0, time, BONE_UNKNOWN, &point, false, 0.25f, 500, 3, false);
                 }
             }     

--- a/source/game_sa/Glass.cpp
+++ b/source/game_sa/Glass.cpp
@@ -561,7 +561,7 @@ void CGlass::BreakGlassPhysically(CVector point, float radius) {
         // Test if point touches any of the model's triangles
         {
             const CColSphere sphere{
-                Multiply3x3_MV(object->GetMatrix(), point - objPos),
+                object->GetMatrix().TransformVector(point - objPos),
                 radius
             };
             CCollision::CalculateTrianglePlanes(colModel);

--- a/source/game_sa/Glass.cpp
+++ b/source/game_sa/Glass.cpp
@@ -105,7 +105,7 @@ void CGlass::CarWindscreenShatters(CVehicle* vehicle) {
     auto& vehMat = (CMatrix&)vehicle->GetMatrix();
 
     // Grab normal and transform it to world space
-    const auto normal = Multiply3x3(
+    const auto normal = Multiply3x3_MV(
         vehMat,
         colModel->m_pColData->m_pTrianglePlanes[glassTriIdx].GetNormal()
     );
@@ -561,7 +561,7 @@ void CGlass::BreakGlassPhysically(CVector point, float radius) {
         // Test if point touches any of the model's triangles
         {
             const CColSphere sphere{
-                Multiply3x3(object->GetMatrix(), point - objPos),
+                Multiply3x3_MV(object->GetMatrix(), point - objPos),
                 radius
             };
             CCollision::CalculateTrianglePlanes(colModel);

--- a/source/game_sa/Occluder.cpp
+++ b/source/game_sa/Occluder.cpp
@@ -50,13 +50,13 @@ bool COccluder::ProcessOneOccluder(CActiveOccluder* activeOccluder)
         && fWidth  / 4.0F != 0.0F
         && fHeight / 4.0F != 0.0F) {
         auto vecWidth = CVector(fWidth / 8.0F, 0.0F, 0.0F);
-        auto vecTransWidth = matTransform * vecWidth;
+        auto vecTransWidth = matTransform.TransformPoint(vecWidth);
 
         auto vecLength = CVector(0.0F, fLength / 8.0F, 0.0F);
-        auto vecTransLength = matTransform * vecLength;
+        auto vecTransLength = matTransform.TransformPoint(vecLength);
 
         auto vecHeight = CVector(0.0F, 0.0F, fHeight / 8.0F);
-        auto vecTransHeight = matTransform * vecHeight;
+        auto vecTransHeight = matTransform.TransformPoint(vecHeight);
 
         CVector aVecArr[6]{
             vecTransLength, -vecTransLength,

--- a/source/game_sa/Occluder.cpp
+++ b/source/game_sa/Occluder.cpp
@@ -126,24 +126,24 @@ bool COccluder::ProcessOneOccluder(CActiveOccluder* activeOccluder)
     CVector vec1, vec2;
     if (fLength / 4.0F == 0.0F) {
         auto vecWidth = CVector(fWidth / 8.0F, 0.0F, 0.0F);
-        vec1 = matTransform * vecWidth;
+        vec1 = matTransform.TransformPoint(vecWidth);
 
         auto vecHeight = CVector(0.0F, 0.0F, fHeight / 8.0F);
-        vec2 = matTransform * vecHeight;
+        vec2 = matTransform.TransformPoint(vecHeight);
     }
     else if (fWidth / 4.0F == 0.0F) {
         auto vecLength = CVector(0.0F, fLength / 8.0F, 0.0F);
-        vec1 = matTransform * vecLength;
+        vec1 = matTransform.TransformPoint(vecLength);
 
         auto vecHeight = CVector(0.0F, 0.0F, fHeight / 8.0F);
-        vec2 = matTransform * vecHeight;
+        vec2 = matTransform.TransformPoint(vecHeight);
     }
     else if (fHeight / 4.0F == 0.0F) {
         auto vecLength = CVector(0.0F, fLength / 8.0F, 0.0F);
-        vec1 = matTransform * vecLength;
+        vec1 = matTransform.TransformPoint(vecLength);
 
         auto vecWidth = CVector(fWidth / 8.0F, 0.0F, 0.0F);
-        vec2 = matTransform * vecWidth;
+        vec2 = matTransform.TransformPoint(vecWidth);
     }
 
     COcclusion::gOccluderCoors[0] = vecPos + vec1 + vec2;
@@ -186,8 +186,8 @@ bool COccluder::ProcessLineSegment(int32 iIndFrom, int32 iIndTo, CActiveOccluder
         vecScreenFrom = COcclusion::gOccluderCoorsOnScreen[iIndFrom];
     }
     else {
-        auto fFromDepth = fabs((TheCamera.m_mViewMatrix * COcclusion::gOccluderCoors[iIndFrom]).z - 1.1F);
-        auto fToDepth = fabs((TheCamera.m_mViewMatrix * COcclusion::gOccluderCoors[iIndTo]).z - 1.1F);
+        auto fFromDepth = fabs((TheCamera.m_mViewMatrix.TransformPoint(COcclusion::gOccluderCoors[iIndFrom])).z - 1.1F);
+        auto fToDepth = fabs((TheCamera.m_mViewMatrix.TransformPoint(COcclusion::gOccluderCoors[iIndTo])).z - 1.1F);
 
         auto fProgress = fToDepth / (fFromDepth + fToDepth);
         vecScreenFrom = (1.0F - fProgress) * COcclusion::gOccluderCoors[iIndTo];
@@ -202,8 +202,8 @@ bool COccluder::ProcessLineSegment(int32 iIndFrom, int32 iIndTo, CActiveOccluder
         vecScreenTo = COcclusion::gOccluderCoorsOnScreen[iIndTo];
     }
     else {
-        auto fFromDepth = fabs((TheCamera.m_mViewMatrix * COcclusion::gOccluderCoors[iIndFrom]).z - 1.1F);
-        auto fToDepth = fabs((TheCamera.m_mViewMatrix * COcclusion::gOccluderCoors[iIndTo]).z - 1.1F);
+        auto fFromDepth = fabs((TheCamera.m_mViewMatrix.TransformPoint(COcclusion::gOccluderCoors[iIndFrom])).z - 1.1F);
+        auto fToDepth = fabs((TheCamera.m_mViewMatrix.TransformPoint(COcclusion::gOccluderCoors[iIndTo])).z - 1.1F);
 
         auto fProgress = fToDepth / (fFromDepth + fToDepth);
         auto vecFrom = (1.0F - fProgress) * COcclusion::gOccluderCoors[iIndTo];

--- a/source/game_sa/Population.cpp
+++ b/source/game_sa/Population.cpp
@@ -1680,7 +1680,7 @@ int32 CPopulation::GeneratePedsAtAttractors(
                 }
             }
 
-            const auto effectPosWS = ent->GetMatrix() * effect->m_pos; // ws = world space
+            const auto effectPosWS = ent->GetMatrix().TransformPoint(effect->m_pos); // ws = world space
             if (!IsEffectInRadius(effectPosWS)) {
                 continue;
             }

--- a/source/game_sa/RegisteredCorona.cpp
+++ b/source/game_sa/RegisteredCorona.cpp
@@ -8,9 +8,9 @@ auto CRegisteredCorona::GetPosition() const -> CVector {
         return m_vPosn;
     }
     if (m_pAttachedTo->GetType() == ENTITY_TYPE_VEHICLE && m_pAttachedTo->AsVehicle()->IsSubBike()) {
-        return m_pAttachedTo->AsBike()->m_mLeanMatrix * m_vPosn;
+        return m_pAttachedTo->AsBike()->m_mLeanMatrix.TransformPoint(m_vPosn);
     }
-    return m_pAttachedTo->GetMatrix() * m_vPosn;
+    return m_pAttachedTo->GetMatrix().TransformPoint(m_vPosn);
 }
 
 auto CRegisteredCorona::CalculateIntensity(float scrZ, float farClip) const -> float {

--- a/source/game_sa/Rope.cpp
+++ b/source/game_sa/Rope.cpp
@@ -175,7 +175,7 @@ void CRope::PickUpObject(CEntity* obj) {
     // TODO: Move model => world space translation into CEntity
     // MultiplyMatrixWithVector should be used here
     CVector height = { {}, {}, CRopes::FindPickupHeight(obj) };
-    m_pAttachedEntity->SetPosn(obj->GetPosition() + Multiply3x3(obj->GetMatrix(), height));
+    m_pAttachedEntity->SetPosn(obj->GetPosition() + Multiply3x3_MV(obj->GetMatrix(), height));
     m_pAttachedEntity->m_bUsesCollision = false;
 
     obj->AsPhysical()->physicalFlags.bAttachedToEntity = true;

--- a/source/game_sa/Rope.cpp
+++ b/source/game_sa/Rope.cpp
@@ -175,7 +175,7 @@ void CRope::PickUpObject(CEntity* obj) {
     // TODO: Move model => world space translation into CEntity
     // MultiplyMatrixWithVector should be used here
     CVector height = { {}, {}, CRopes::FindPickupHeight(obj) };
-    m_pAttachedEntity->SetPosn(obj->GetPosition() + Multiply3x3_MV(obj->GetMatrix(), height));
+    m_pAttachedEntity->SetPosn(obj->GetPosition() + obj->GetMatrix().TransformVector(height));
     m_pAttachedEntity->m_bUsesCollision = false;
 
     obj->AsPhysical()->physicalFlags.bAttachedToEntity = true;

--- a/source/game_sa/Scripts/Commands/Character.cpp
+++ b/source/game_sa/Scripts/Commands/Character.cpp
@@ -1023,7 +1023,7 @@ auto GetCharWeaponInSlot(CPed& ped, eWeaponSlot slut) {
 
 // GET_OFFSET_FROM_CHAR_IN_WORLD_COORDS
 auto GetOffsetFromCharInWorldCoords(CPed& ped, CVector offset) {
-    return ped.GetMatrix().TransformPoint(offset)
+    return ped.GetMatrix().TransformPoint(offset);
 }
 
 // HAS_CHAR_BEEN_PHOTOGRAPHED

--- a/source/game_sa/Scripts/Commands/Character.cpp
+++ b/source/game_sa/Scripts/Commands/Character.cpp
@@ -1023,7 +1023,7 @@ auto GetCharWeaponInSlot(CPed& ped, eWeaponSlot slut) {
 
 // GET_OFFSET_FROM_CHAR_IN_WORLD_COORDS
 auto GetOffsetFromCharInWorldCoords(CPed& ped, CVector offset) {
-    return ped.GetMatrix() * offset;
+    return ped.GetMatrix().TransformPoint(offset)
 }
 
 // HAS_CHAR_BEEN_PHOTOGRAPHED

--- a/source/game_sa/Tasks/TaskTypes/SeekEntity/TaskComplexSeekEntity.h
+++ b/source/game_sa/Tasks/TaskTypes/SeekEntity/TaskComplexSeekEntity.h
@@ -356,7 +356,7 @@ public:
     
         ped->AttachPedToEntity(
             commonBoat,
-            Multiply3x3(Invert(commonBoat->GetMatrix()), newPedPos - boatPos),
+            Multiply3x3_MV(Invert(commonBoat->GetMatrix()), newPedPos - boatPos),
             (int16)CGeneral::LimitRadianAngle(CGeneral::GetRadianAngleBetweenPoints(pedToBoatDir, {})),
             0.2f,
             ped->GetActiveWeapon().m_Type

--- a/source/game_sa/Tasks/TaskTypes/SeekEntity/TaskComplexSeekEntity.h
+++ b/source/game_sa/Tasks/TaskTypes/SeekEntity/TaskComplexSeekEntity.h
@@ -356,7 +356,7 @@ public:
     
         ped->AttachPedToEntity(
             commonBoat,
-            Multiply3x3_MV(Invert(commonBoat->GetMatrix()), newPedPos - boatPos),
+            Invert(commonBoat->GetMatrix()).TransformVector(newPedPos - boatPos),
             (int16)CGeneral::LimitRadianAngle(CGeneral::GetRadianAngleBetweenPoints(pedToBoatDir, {})),
             0.2f,
             ped->GetActiveWeapon().m_Type

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
@@ -126,8 +126,7 @@ CTask* CTaskComplexWalkAlongsidePed::ControlSubTask(CPed* ped) {
 
     bool bChangedAnimSpeed = false;
     if (pedTaskGoToPoint && !pedTaskFollowNodeRoute) { // 0x685308 (Inverted)
-        auto targetPtForPed = m_TargetPed->GetMatrix() * m_Offset;
-
+        auto targetPtForPed = m_TargetPed->GetMatrix().TransformPoint(m_Offset);
         if (isTargetMoving) { // 0x68535C
             if (m_TargetPed->GetPosition().Dot(m_TargetPed->GetForward()) - targetPtForPed.Dot(m_TargetPed->GetForward()) < 0.f) { // Target pt is behind target ped (I think?)
                 if (pedWalkAnim) { // 0x6853C6

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexWalkRoundBuildingAttempt.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexWalkRoundBuildingAttempt.cpp
@@ -265,7 +265,7 @@ CTask* CTaskComplexWalkRoundBuildingAttempt::CreateFirstSubTask(CPed* ped) {
             ped->bIgnoreHeightCheckOnGotoPointTask = false;
             return nullptr;
         }
-        m_targetPos = m_targetEntity->GetMatrix() * m_offset;
+        m_targetPos = m_targetEntity->GetMatrix().TransformPoint(m_offset);
     }
 
     ped->bIgnoreHeightCheckOnGotoPointTask = true;

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexWalkRoundBuildingAttempt.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexWalkRoundBuildingAttempt.cpp
@@ -288,7 +288,7 @@ CTask* CTaskComplexWalkRoundBuildingAttempt::CreateFirstSubTask(CPed* ped) {
 // 0x658020
 CTask* CTaskComplexWalkRoundBuildingAttempt::ControlSubTask(CPed* ped) {
     if (m_isWalkingAroundEntity) {
-        if (!m_targetEntity || (m_targetEntity->GetMatrix() * m_offset - m_targetPos).SquaredMagnitude() >= sq(4.f)) {
+        if (!m_targetEntity || (m_targetEntity->GetMatrix().TransformPoint(m_offset - m_targetPos)).SquaredMagnitude() >= sq(4.f)) {
             m_justAbort = true;
             return CreateSubTask(TASK_SIMPLE_STAND_STILL, ped);
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
@@ -115,7 +115,7 @@ bool CTaskSimpleClimb::ProcessPed_Reversed(CPed* ped) {
     CVector posn = m_vecHandholdPos;
 
     if (m_pClimbEnt->IsPhysical()) {
-        posn = m_pClimbEnt->GetMatrix() * posn;
+        posn = m_pClimbEnt->GetMatrix().TransformPoint(posn);
         fAngle += m_pClimbEnt->GetHeading();
     }
 
@@ -309,7 +309,7 @@ CEntity* CTaskSimpleClimb::TestForClimb(CPed* ped, CVector& outClimbPos, float& 
         float angle = outClimbHeading;
 
         if (entity->IsPhysical()) {
-            point = entity->GetMatrix() * point;
+            point = entity->GetMatrix().TransformPoint(point);
             angle += entity->GetHeading();
         }
 
@@ -769,7 +769,7 @@ void CTaskSimpleClimb::GetCameraTargetPos(CPed* ped, CVector& vecTarget) {
     CVector point = m_vecHandholdPos;
     float fAngle = m_fHandholdHeading;
     if (m_pClimbEnt->IsPhysical()) {
-        point = m_pClimbEnt->GetMatrix() * point;
+        point = m_pClimbEnt->GetMatrix().TransformPoint(point);
         fAngle += m_pClimbEnt->GetHeading();
     }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
@@ -365,7 +365,7 @@ void* CTaskSimpleClimb::ScanToGrabSectorList(CPtrList* sectorList, CPed* ped, CV
                 )
             )
         {
-            if (DistanceBetweenPoints(entity->GetBoundCentre(), ped->GetMatrix() * cm->GetBoundCenter()) >= entity->GetModelInfo()->GetColModel()->GetBoundRadius() + cm->GetBoundRadius())
+            if (DistanceBetweenPoints(entity->GetBoundCentre(), ped->GetMatrix().TransformPoint(cm->GetBoundCenter())) >= entity->GetModelInfo()->GetColModel()->GetBoundRadius() + cm->GetBoundRadius())
                 continue;
 
             int32 numSpheres = -1;
@@ -490,7 +490,7 @@ CEntity* CTaskSimpleClimb::ScanToGrab(CPed* ped, CVector& climbPos, float& fAngl
 
     climbPos = ped->GetPosition() + ped->GetForward() * 10.0f;
 
-    auto outPoint = *ped->m_matrix * ms_ClimbColModel.GetBoundCenter();
+    auto outPoint = ped->m_matrix->TransformPoint(ms_ClimbColModel.GetBoundCenter());
 
     int32 startSectorX = CWorld::GetSectorX(outPoint.x - ms_ClimbColModel.GetBoundRadius());
     int32 startSectorY = CWorld::GetSectorY(outPoint.y - ms_ClimbColModel.GetBoundRadius());
@@ -530,7 +530,7 @@ CEntity* CTaskSimpleClimb::ScanToGrab(CPed* ped, CVector& climbPos, float& fAngl
 
     if (collidedEntity) {
         if (collidedEntity->IsPhysical()) {
-            climbPos = Invert(collidedEntity->GetMatrix()) * climbPos;
+            climbPos = Invert(collidedEntity->GetMatrix()).TransformPoint(climbPos);
             fAngle -= collidedEntity->GetHeading();
         }
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
@@ -694,7 +694,7 @@ void CTaskSimpleClimb::GetCameraStickModifier(CEntity* entity, float& fVerticalA
         float fAngle = m_fHandholdHeading;
 
         if (m_pClimbEnt->IsPhysical()) {
-            vec = *m_pClimbEnt->m_matrix * vec;
+            vec = m_pClimbEnt->m_matrix->TransformPoint(vec);
             fAngle += m_pClimbEnt->GetHeading();
         }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
@@ -257,7 +257,7 @@ bool CTaskSimpleHoldEntity::ProcessPed_Reversed(CPed* ped) {
                 if ((!animAssoc || taskPickUpEntity->m_fMovePedUntilAnimProgress > animAssoc->m_CurrentTime)
                     && (taskPickUpEntity->m_vecPickuposn.x != 0.0f || taskPickUpEntity->m_vecPickuposn.y != 0.0f))
                 {
-                    CVector outPoint = entityToHold->GetMatrix() * taskPickUpEntity->m_vecPickuposn;
+                    CVector outPoint = entityToHold->GetMatrix().TransformPoint(taskPickUpEntity->m_vecPickuposn);
                     outPoint -= ped->GetPosition();
                     ped->m_vecAnimMovingShiftLocal.x += DotProduct(&outPoint, &ped->GetRight()) / CTimer::GetTimeStep() * 0.1f;
                     ped->m_vecAnimMovingShiftLocal.y += DotProduct(&outPoint, &ped->GetForward()) / CTimer::GetTimeStep() * 0.1f ;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
@@ -314,7 +314,7 @@ bool CTaskSimpleHoldEntity::SetPedPosition_Reversed(CPed* ped) {
                     m_pEntityToHold->SetPosn(entityToHoldPos);
                 }
                 else {
-                    CVector entityToHoldPos = Multiply3x3(ped->GetMatrix(), m_vecPosition);
+                    CVector entityToHoldPos = Multiply3x3_MV(ped->GetMatrix(), m_vecPosition);
                     RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
                     int32 animIndex = RpHAnimIDGetIndex(pHAnimHierarchy, ped->m_apBones[m_nBoneFrameId]->m_nNodeId);
                     RwMatrix* pBoneMatrix = RpHAnimHierarchyGetMatrixArray(pHAnimHierarchy);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
@@ -314,7 +314,7 @@ bool CTaskSimpleHoldEntity::SetPedPosition_Reversed(CPed* ped) {
                     m_pEntityToHold->SetPosn(entityToHoldPos);
                 }
                 else {
-                    CVector entityToHoldPos = Multiply3x3_MV(ped->GetMatrix(), m_vecPosition);
+                    CVector entityToHoldPos = ped->GetMatrix().TransformVector(m_vecPosition);
                     RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
                     int32 animIndex = RpHAnimIDGetIndex(pHAnimHierarchy, ped->m_apBones[m_nBoneFrameId]->m_nNodeId);
                     RwMatrix* pBoneMatrix = RpHAnimHierarchyGetMatrixArray(pHAnimHierarchy);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleJump.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleJump.cpp
@@ -114,7 +114,7 @@ bool CTaskSimpleJump::CheckIfJumpBlocked(CPed* ped) {
     m_bClimbJump = CWorld::TestSphereAgainstWorld(posn, 0.25F, 0, true, true, false, true, false, false) != 0;
 
     CVector savedPedPosition = ped->GetPosition();
-    ped->SetPosn((*ped->m_matrix) * CVector(0.0F, 0.0F, 0.75F));
+    ped->SetPosn((*ped->m_matrix).TransformPoint(CVector(0.0F, 0.0F, 0.75F)));
 
     for (uint32 i = 0; i < pedColData->m_nNumSpheres; i++)
         pedColData->m_pSpheres[i].m_fRadius = 0.3F;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimplePlayerOnFoot.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimplePlayerOnFoot.cpp
@@ -423,7 +423,7 @@ void CTaskSimplePlayerOnFoot::ProcessPlayerWeapon(CPlayerPed* player) {
                         CWeapon* activeWeapon = &player->m_aWeapons[activeWeaponSlot];
                         if (CCamera::GetActiveCamera().m_nMode == MODE_CAMERA && CTimer::GetTimeInMS() > activeWeapon->m_TimeForNextShotMs) {
                             CVector firingPoint(0.0f, 0.0f, 0.6f);
-                            CVector outputFiringPoint = *player->m_matrix * firingPoint;
+                            CVector outputFiringPoint = player->m_matrix->TransformPoint(firingPoint);
                             activeWeapon->Fire(player, &outputFiringPoint, nullptr, nullptr, nullptr, nullptr);
                         }
                         break;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
@@ -61,6 +61,6 @@ void CTaskSimpleRunNamedAnim::OffsetPedPosition(CPed* ped) {
     ped->UpdateRpHAnim();
     ped->m_bDontUpdateHierarchy = true;
     auto& pos = ped->GetPosition();
-    pos += Multiply3x3(*ped->m_matrix, m_vecOffsetAtEnd);
+    pos += Multiply3x3_MV(*ped->m_matrix, m_vecOffsetAtEnd);
     m_bOffsetAvailable = false;
 }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleRunNamedAnim.cpp
@@ -61,6 +61,6 @@ void CTaskSimpleRunNamedAnim::OffsetPedPosition(CPed* ped) {
     ped->UpdateRpHAnim();
     ped->m_bDontUpdateHierarchy = true;
     auto& pos = ped->GetPosition();
-    pos += Multiply3x3_MV(*ped->m_matrix, m_vecOffsetAtEnd);
+    pos += ped->m_matrix->TransformVector(m_vecOffsetAtEnd);
     m_bOffsetAvailable = false;
 }

--- a/source/game_sa/TrafficLights.cpp
+++ b/source/game_sa/TrafficLights.cpp
@@ -341,10 +341,10 @@ void CTrafficLights::DisplayActualLight(CEntity* entity) {
         auto p4 = CVector(vecMidPoint.x, vecMidPoint.y, vecCorner2.z);
 
         CShinyTexts::RegisterOne(
-            entity->GetMatrix() * p1,
-            entity->GetMatrix() * p2,
-            entity->GetMatrix() * p3,
-            entity->GetMatrix() * p4,
+            entity->GetMatrix().TransformPoint(p1),
+            entity->GetMatrix().TransformPoint(p2),
+            entity->GetMatrix().TransformPoint(p3),
+            entity->GetMatrix().TransformPoint(p4),
             0.5F,
             0.0F,
             0.0F,
@@ -371,10 +371,10 @@ void CTrafficLights::DisplayActualLight(CEntity* entity) {
         auto p4 = CVector(vecCorner1.x, vecCorner1.y, vecCorner2.z);
 
         CShinyTexts::RegisterOne(
-            entity->GetMatrix()* p1,
-            entity->GetMatrix()* p2,
-            entity->GetMatrix()* p3,
-            entity->GetMatrix()* p4,
+            entity->GetMatrix().TransformPoint(p1),
+            entity->GetMatrix().TransformPoint(p2),
+            entity->GetMatrix().TransformPoint(p3),
+            entity->GetMatrix().TransformPoint(p4),
             1.0F,
             0.0F,
             0.5F,

--- a/source/game_sa/TrafficLights.cpp
+++ b/source/game_sa/TrafficLights.cpp
@@ -190,7 +190,7 @@ void CTrafficLights::DisplayActualLight(CEntity* entity) {
         if (effect->m_type != e2dEffectType::EFFECT_LIGHT)
             continue;
 
-        auto vecLightPos = entity->GetMatrix() * effect->m_pos;
+        auto vecLightPos = entity->GetMatrix().TransformPoint(effect->m_pos);
         vecCenter += vecLightPos;
         int32 iColorState = eTrafficLightsState::LIGHT_GREEN;
         if (effect->light.m_color.red > 200) {

--- a/source/game_sa/Weapon.cpp
+++ b/source/game_sa/Weapon.cpp
@@ -1577,7 +1577,7 @@ bool CWeapon::Fire(CEntity* firedBy, CVector* startPosn, CVector* barrelPosn, CE
         ? barrelPosn
         : &point;
     if (!startPosn) {
-        point     = firedBy->GetMatrix() * point;
+        point     = firedBy->GetMatrix().TransformPoint(point);
         startPosn = &point;
     }
 

--- a/source/game_sa/World.cpp
+++ b/source/game_sa/World.cpp
@@ -949,7 +949,7 @@ void CWorld::FindObjectsIntersectingAngledCollisionBoxSectorList(CPtrList& ptrLi
         entity->SetCurrentScanCode();
 
         CColSphere sphere{
-            Multiply3x3(entity->GetPosition() - point, transform),
+            Multiply3x3_VM(entity->GetPosition() - point, transform),
             entity->GetColModel()->GetBoundRadius()
         };
         if (CCollision::TestSphereBox(sphere, box)) {
@@ -1851,12 +1851,12 @@ void CWorld::TriggerExplosionSectorList(CPtrList& ptrList, const CVector& point,
             CColPoint cp{};
             float maxTouchDist{ 100'000.f };
             if (CCollision::ProcessSphereBox(
-                CColSphere{ Multiply3x3(veh->GetMatrix(), -entityToPointDir), entityToPointDist },
+                CColSphere{ Multiply3x3_MV(veh->GetMatrix(), -entityToPointDir), entityToPointDist },
                 veh->GetColModel()->m_boundBox,
                 cp,
                 maxTouchDist)
             ) {
-                auto colNormal = Multiply3x3(veh->GetMatrix(), -cp.m_vecNormal);
+                auto colNormal = Multiply3x3_MV(veh->GetMatrix(), -cp.m_vecNormal);
                 if (auto& z = colNormal.z; z >= -0.f) { // TODO: Wat is dis?
                     if (z < 0.2f && z > 0.f)
                         z += 0.2f;
@@ -1864,7 +1864,7 @@ void CWorld::TriggerExplosionSectorList(CPtrList& ptrList, const CVector& point,
                     z = -0.2f;
                 }
 
-                colPointPos  = Multiply3x3(veh->GetMatrix(), cp.m_vecPoint);
+                colPointPos  = Multiply3x3_MV(veh->GetMatrix(), cp.m_vecPoint);
                 const auto colPointToExploPointDist = ((colPointPos + veh->GetPosition()) - point).Magnitude();
 
                 // TODO: Document this a little better pls
@@ -2473,7 +2473,7 @@ void CWorld::RepositionOneObject(CEntity* object) {
     })) {
         if (const auto CD = colModel->m_pColData) {
             if (CD->m_nNumBoxes == 1) {
-                RecalcZPosAtPoint(Multiply3x3(object->GetMatrix(), CD->m_pBoxes[0].GetCenter()));
+                RecalcZPosAtPoint(Multiply3x3_MV(object->GetMatrix(), CD->m_pBoxes[0].GetCenter()));
             } else if (CD->m_nNumSpheres) {
                 auto point{ object->GetPosition() };
                 point.z = 1000.f;
@@ -2487,7 +2487,7 @@ void CWorld::RepositionOneObject(CEntity* object) {
                 if (point.z >= 1000.f)
                     RecalcZPosAtPoint(object->GetPosition());
                 else
-                    RecalcZPosAtPoint(Multiply3x3(object->GetMatrix(), point));
+                    RecalcZPosAtPoint(Multiply3x3_MV(object->GetMatrix(), point));
             }
         } else {
             RecalcZPosAtPoint(object->GetPosition());

--- a/source/game_sa/World.cpp
+++ b/source/game_sa/World.cpp
@@ -949,7 +949,7 @@ void CWorld::FindObjectsIntersectingAngledCollisionBoxSectorList(CPtrList& ptrLi
         entity->SetCurrentScanCode();
 
         CColSphere sphere{
-            Multiply3x3_VM(entity->GetPosition() - point, transform),
+            transform.InverseTransformVector(entity->GetPosition() - point),
             entity->GetColModel()->GetBoundRadius()
         };
         if (CCollision::TestSphereBox(sphere, box)) {

--- a/source/game_sa/World.cpp
+++ b/source/game_sa/World.cpp
@@ -1851,12 +1851,12 @@ void CWorld::TriggerExplosionSectorList(CPtrList& ptrList, const CVector& point,
             CColPoint cp{};
             float maxTouchDist{ 100'000.f };
             if (CCollision::ProcessSphereBox(
-                CColSphere{ Multiply3x3_MV(veh->GetMatrix(), -entityToPointDir), entityToPointDist },
+                CColSphere{ veh->GetMatrix().TransformVector(-entityToPointDir), entityToPointDist },
                 veh->GetColModel()->m_boundBox,
                 cp,
                 maxTouchDist)
             ) {
-                auto colNormal = Multiply3x3_MV(veh->GetMatrix(), -cp.m_vecNormal);
+                auto colNormal = veh->GetMatrix().TransformVector(-cp.m_vecNormal);
                 if (auto& z = colNormal.z; z >= -0.f) { // TODO: Wat is dis?
                     if (z < 0.2f && z > 0.f)
                         z += 0.2f;
@@ -1864,7 +1864,7 @@ void CWorld::TriggerExplosionSectorList(CPtrList& ptrList, const CVector& point,
                     z = -0.2f;
                 }
 
-                colPointPos  = Multiply3x3_MV(veh->GetMatrix(), cp.m_vecPoint);
+                colPointPos  = veh->GetMatrix().TransformVector(cp.m_vecPoint);
                 const auto colPointToExploPointDist = ((colPointPos + veh->GetPosition()) - point).Magnitude();
 
                 // TODO: Document this a little better pls
@@ -2473,7 +2473,7 @@ void CWorld::RepositionOneObject(CEntity* object) {
     })) {
         if (const auto CD = colModel->m_pColData) {
             if (CD->m_nNumBoxes == 1) {
-                RecalcZPosAtPoint(Multiply3x3_MV(object->GetMatrix(), CD->m_pBoxes[0].GetCenter()));
+                RecalcZPosAtPoint(object->GetMatrix().TransformVector(CD->m_pBoxes[0].GetCenter()));
             } else if (CD->m_nNumSpheres) {
                 auto point{ object->GetPosition() };
                 point.z = 1000.f;
@@ -2487,7 +2487,7 @@ void CWorld::RepositionOneObject(CEntity* object) {
                 if (point.z >= 1000.f)
                     RecalcZPosAtPoint(object->GetPosition());
                 else
-                    RecalcZPosAtPoint(Multiply3x3_MV(object->GetMatrix(), point));
+                    RecalcZPosAtPoint(object->GetMatrix().TransformVector(point));
             }
         } else {
             RecalcZPosAtPoint(object->GetPosition());

--- a/source/game_sa/common.cpp
+++ b/source/game_sa/common.cpp
@@ -92,7 +92,7 @@ bool CalcScreenCoors(const CVector& in, CVector* out, float* screenX, float* scr
     return plugin::CallAndReturn<bool, 0x71DA00, const CVector&, CVector*, float*, float*>(in, out, screenX, screenY);
 
     // TODO: Figure out how to get screen size..
-    CVector screen =  TheCamera.m_mViewMatrix * in;
+    CVector screen =  TheCamera.m_mViewMatrix.TransformPoint(in);
     if (screen.z <= 1.0f)
         return false;
 

--- a/source/game_sa/common.cpp
+++ b/source/game_sa/common.cpp
@@ -118,7 +118,7 @@ bool CalcScreenCoors(const CVector& in, CVector* out, float* screenX, float* scr
 bool CalcScreenCoors(const CVector& in, CVector* out) {
     return plugin::CallAndReturn<bool, 0x71DAB0, const CVector&, CVector*>(in, out);
 
-    *out = TheCamera.GetViewMatrix() * in;
+    *out = TheCamera.GetViewMatrix().TransformPoint(in);
     if (out->z <= 1.0f)
         return false;
 


### PR DESCRIPTION
Adds:
- `TransformPoint`
- `TransformVector`
- `InverseTransformPoint`
- `InverseTransformVector`
These are all more optimized versions of existing stuff, plan is to eventually replace those with these (And drop that garbage `operator*` overload for `CMatrix` entirely, it's confusing as fuck)